### PR TITLE
Add auth endpoints: signup, login, Google OAuth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+## Project Structure
+
+Monorepo with two components:
+- **Server**: Node.js 22.15.0 backend, TypeScript, Express 5, Sequelize ORM, PostgreSQL
+- **Client**: React frontend with Vite
+
+Docker Compose for orchestration. All cross-project commands are in the root `Makefile`.
+
+## Task-Type Quick Reference
+
+| Task Type | Read This |
+|-----------|-----------|
+| Creating a database model | `/create-model` skill |
+| Creating library functions | `/create-lib` skill |
+| Creating an API endpoint | `/create-endpoint` skill |
+| Debugging flaky tests | `/diagnose-flaky` skill |
+| React component work | Client Architecture section below |
+
+## Codebase Map
+
+### Server (`/server/src/`)
+- `api/` — REST endpoints (one dir per module: `index.ts`, `[module].api.ts`, `[module].api.test.ts`, `[module].api.docs.yaml`)
+- `api/routes.ts` — Central route mounting
+- `api/security.ts` — Auth middleware (JWT, Basic Auth, role checks)
+- `api/validation.ts` — Request validation middleware
+- `db/models/` — Sequelize models (one dir per model)
+- `db/migrations/` — Database migrations
+- `lib/` — Business logic (`index.ts`, `[module].lib.ts`, `[module].lib.test.ts`)
+- `utils/errors.ts` — Error classes (NotFoundError, AuthenticationError, ValidationError, etc.)
+- `utils/jwt.ts` — JWT token generation
+- `test/testDataGenerator.ts` — Factory functions for test data
+- `middleware/errorHandler.ts` — Express error handler
+
+### Client (`/client/src/`)
+- `Components/` — React components
+- `App.tsx` — Root component
+
+## Development Commands
+
+All commands run via `make` from the project root. These execute inside Docker containers.
+
+### Essential Commands
+- `make prettier-all` — **Run before every push** to format all files
+- `make test-server` — Run server tests
+- `make lint-server` — Run server linter
+- `make build-server` — Build TypeScript to dist/
+- `make build-and-test-server` — Build then test
+- `make test-client` — Run client tests
+- `make lint-client` — Run client linter
+- `make prettier-server` — Format server files only
+- `make prettier-client` — Format client files only
+
+### Database Commands
+- `make migrate` — Run pending migrations
+- `make migrate-all` — Run migrations for dev and test DBs
+- `make generate-migration NAME=migration-name` — Create a new migration
+
+### Docker Commands
+- `make install` — Initial setup (copy env files, set ports, build containers)
+- `make launch` — Start all services
+- `make launch-detached` — Start all services in background
+- `make terminate` — Stop all services
+- `make logs` — Tail all logs
+- `make logs-server` — Tail server logs
+
+## Before Pushing
+
+Always run:
+```
+make prettier-all
+```
+
+## Code Style Guide
+
+### TypeScript Best Practices
+- **All new files must be TypeScript** — no new `.js` files
+- Use type inference where context makes types obvious
+- Explicitly annotate function parameters and return types
+- Import proper types instead of using `any`
+- Document why code exists, not what it does
+
+### Model Enum Pattern
+
+Define enum constants in the model file as the single source of truth:
+
+```typescript
+export const USER_ROLES = ["admin", "user", "guest"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+```
+
+Use in routes for validation:
+```typescript
+import { USER_ROLES } from "../../db/models/user.model";
+import { checkBodyEnum } from "../validation";
+
+router.put("/:id/role", checkBodyEnum("role", USER_ROLES), controller.updateRole);
+```
+
+## Testing Strategy
+
+### Server Testing
+- Mocha + Chai for test framework with co-located `.test.ts` files
+- Integration tests for API endpoints using Supertest
+- HTTP mocking with Nock for external API calls
+- Function mocking with Sinon
+- Factory functions in `test/testDataGenerator.ts`
+- Tests clear the database between runs (`afterEach`)
+
+### Client Testing
+- Vitest with jsdom environment
+- React Testing Library for component behavior testing
+
+## Building New Endpoints (TDD)
+
+Follow this exact procedure:
+1. Write library tests in `/server/src/lib/[module]/[module].lib.test.ts`
+2. See them fail (red)
+3. Write library functions in `/server/src/lib/[module]/[module].lib.ts`
+4. See them succeed (green)
+5. Run `make build-server && make lint-server && make test-server`
+6. Write integration tests in `/server/src/api/[module]/[module].api.test.ts`
+7. See them fail (red)
+8. Hook up routing and controller in `/server/src/api/[module]/`
+9. See them succeed (green)
+10. Run `make build-server && make lint-server && make test-server`
+11. Add API documentation in `/server/src/api/[module]/[module].api.docs.yaml`
+12. Run `make build-server` to compile documentation
+
+**Important**: Implement one function at a time. Write tests for one function, implement it, verify, then move to the next.
+
+## API Design
+- RESTful endpoints with `/v1/` versioning
+- Resource-based organization — no "summary" endpoints combining unrelated data
+- JWT authentication via `authenticate` middleware in `security.ts`
+- Validation via middleware from `validation.ts` (e.g., `checkBodyFor`, `checkBodyEnum`)
+- Error handling via custom error classes thrown from lib layer
+
+## Documentation Standards
+- OpenAPI/Swagger YAML in `.api.docs.yaml` files
+- Never use relative paths between YAML files
+- Reference components as if all definitions are in a single file
+- Use `$ref: '#/components/responses/400'` for common error responses
+
+## Docker & Multi-Instance Support
+- `COMPOSE_PROJECT_NAME` in root `.env` handles container naming — never use hardcoded `container_name` in `docker-compose.yaml`
+- Port variables (`POSTGRES_PORT`, `SERVER_PORT`, etc.) in root `.env` enable multiple instances
+
+## Skill Routing
+
+When the user's request matches an available skill, invoke it using the Skill tool as your FIRST action.
+
+Key routing rules:
+- Bugs, errors, "why is this broken" → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Design system, brand → invoke design-consultation
+- Architecture review → invoke plan-eng-review
+- Code quality, health check → invoke health

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,11 @@
 services:
   # Uncomment to enable Redis (also add REDIS_URL=redis://redis:6379 to server/.env)
   # redis:
-  #   container_name: "YOUR_PROJECT_NAME-redis"
   #   image: "redis:alpine"
   #   ports:
   #     - "127.0.0.1:${REDIS_PORT:-6379}:6379"
 
   postgres:
-    container_name: "YOUR_PROJECT_NAME-postgres"
     user: postgres
     build: ./docker/postgres
     ports:
@@ -26,7 +24,6 @@ services:
       start_period: 80s  
 
   server:
-    container_name: "YOUR_PROJECT_NAME-server"
     build:
       context: ./server
       dockerfile: Dockerfile
@@ -47,7 +44,6 @@ services:
       ["npm", "run", "dev"]
 
   worker:
-    container_name: "YOUR_PROJECT_NAME-worker"
     build:
       context: ./server
       dockerfile: Dockerfile
@@ -69,7 +65,6 @@ services:
       ["npm", "run", "worker"]
 
   migrate:
-    container_name: "YOUR_PROJECT_NAME-migrate"
     build:
       context: ./server
       dockerfile: Dockerfile

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
+        "bcrypt": "^6.0.0",
         "body-parser": "^2.2.0",
         "bullmq": "^5.70.1",
         "compression": "^1.8.0",
         "express": "^5.1.0",
         "express-bearer-token": "^3.0.0",
         "express-jwt": "^8.5.1",
+        "google-auth-library": "^10.6.2",
         "ioredis": "^5.10.0",
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.0",
@@ -32,6 +34,7 @@
       "devDependencies": {
         "@eslint/js": "^9.25.1",
         "@faker-js/faker": "^10.3.0",
+        "@types/bcrypt": "^6.0.0",
         "@types/body-parser": "^1.19.5",
         "@types/chai": "^5.2.1",
         "@types/compression": "^1.7.5",
@@ -665,6 +668,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/bluebird": {
       "version": "3.5.42",
@@ -1327,6 +1340,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -1467,6 +1489,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1484,6 +1526,29 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2168,6 +2233,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2764,6 +2838,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2830,6 +2910,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2960,6 +3063,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -3039,6 +3154,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -3178,6 +3321,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3274,6 +3443,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -3591,6 +3773,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -4223,6 +4414,15 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-cron": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
@@ -4230,6 +4430,55 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -6335,6 +6584,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,12 +24,14 @@
   "dependencies": {
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
+    "bcrypt": "^6.0.0",
     "body-parser": "^2.2.0",
     "bullmq": "^5.70.1",
     "compression": "^1.8.0",
     "express": "^5.1.0",
     "express-bearer-token": "^3.0.0",
     "express-jwt": "^8.5.1",
+    "google-auth-library": "^10.6.2",
     "ioredis": "^5.10.0",
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.0",
@@ -45,6 +47,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.1",
     "@faker-js/faker": "^10.3.0",
+    "@types/bcrypt": "^6.0.0",
     "@types/body-parser": "^1.19.5",
     "@types/chai": "^5.2.1",
     "@types/compression": "^1.7.5",

--- a/server/src/api/auth/auth.api.docs.yaml
+++ b/server/src/api/auth/auth.api.docs.yaml
@@ -1,0 +1,148 @@
+paths:
+  /v1/auth/signup:
+    post:
+      tags:
+        - Authentication
+      summary: Create a new user account
+      description: Register a new user with email and password. Returns the user and a JWT token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+                - firstName
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                password:
+                  type: string
+                  minLength: 1
+                  example: mypassword123
+                firstName:
+                  type: string
+                  example: Jane
+                lastName:
+                  type: string
+                  example: Doe
+      responses:
+        '201':
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+                  token:
+                    type: string
+        '400':
+          description: Missing required fields
+        '409':
+          description: A user with this email already exists
+
+  /v1/auth/login:
+    post:
+      tags:
+        - Authentication
+      summary: Log in with email and password
+      description: Authenticate with email and password. Returns the user and a JWT token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                password:
+                  type: string
+                  example: mypassword123
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+                  token:
+                    type: string
+        '400':
+          description: Missing required fields
+        '401':
+          description: Invalid email or password
+
+  /v1/auth/google:
+    post:
+      tags:
+        - Authentication
+      summary: Sign in with Google
+      description: >
+        Exchange a Google ID token for a JWT. Creates a new user if one
+        does not exist. Only available when GOOGLE_CLIENT_ID is configured.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - idToken
+              properties:
+                idToken:
+                  type: string
+                  description: Google ID token from client-side sign-in
+      responses:
+        '200':
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+                  token:
+                    type: string
+        '400':
+          description: Google sign-in not configured or missing idToken
+        '401':
+          description: Invalid Google ID token
+
+components:
+  schemas:
+    UserJwtRepr:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        firstName:
+          type: string
+        lastName:
+          type: string
+        displayName:
+          type: string
+        email:
+          type: string
+          format: email
+        profileImageUrl:
+          type: string
+        role:
+          type: string
+          enum: [admin, user, guest]

--- a/server/src/api/auth/auth.api.docs.yaml
+++ b/server/src/api/auth/auth.api.docs.yaml
@@ -31,7 +31,7 @@ paths:
                   type: string
                   example: Doe
       responses:
-        '201':
+        "201":
           description: User created successfully
           content:
             application/json:
@@ -39,12 +39,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: '#/components/schemas/UserJwtRepr'
+                    $ref: "#/components/schemas/UserJwtRepr"
                   token:
                     type: string
-        '400':
+        "400":
           description: Missing required fields
-        '409':
+        "409":
           description: A user with this email already exists
 
   /v1/auth/login:
@@ -71,7 +71,7 @@ paths:
                   type: string
                   example: mypassword123
       responses:
-        '200':
+        "200":
           description: Login successful
           content:
             application/json:
@@ -79,12 +79,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: '#/components/schemas/UserJwtRepr'
+                    $ref: "#/components/schemas/UserJwtRepr"
                   token:
                     type: string
-        '400':
+        "400":
           description: Missing required fields
-        '401':
+        "401":
           description: Invalid email or password
 
   /v1/auth/google:
@@ -108,7 +108,7 @@ paths:
                   type: string
                   description: Google ID token from client-side sign-in
       responses:
-        '200':
+        "200":
           description: Authentication successful
           content:
             application/json:
@@ -116,12 +116,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: '#/components/schemas/UserJwtRepr'
+                    $ref: "#/components/schemas/UserJwtRepr"
                   token:
                     type: string
-        '400':
+        "400":
           description: Google sign-in not configured or missing idToken
-        '401':
+        "401":
           description: Invalid Google ID token
 
 components:

--- a/server/src/api/auth/auth.api.test.ts
+++ b/server/src/api/auth/auth.api.test.ts
@@ -1,0 +1,221 @@
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import request from 'supertest';
+import * as bcrypt from 'bcrypt';
+import { LoginTicket, OAuth2Client, TokenPayload } from 'google-auth-library';
+import app from '../../server';
+import User from '../../db/models/user.model';
+import config from '../../config/config';
+
+function mockTicket(payload: TokenPayload): LoginTicket {
+  const ticket = new LoginTicket();
+  sinon.stub(ticket, 'getPayload').returns(payload);
+  return ticket;
+}
+
+describe('Auth API', function () {
+  describe('POST /v1/auth/signup', function () {
+    it('creates a new user and returns a token', function (done) {
+      request(app)
+        .post('/v1/auth/signup')
+        .send({
+          email: 'test@example.com',
+          password: 'password123',
+          firstName: 'Test',
+          lastName: 'User',
+        })
+        .expect(201)
+        .end(function (err, res) {
+          if (err) return done(err);
+          assert.exists(res.body.token);
+          assert.equal(res.body.user.email, 'test@example.com');
+          assert.equal(res.body.user.firstName, 'Test');
+          assert.equal(res.body.user.lastName, 'User');
+          assert.equal(res.body.user.role, 'user');
+          assert.exists(res.body.user.id);
+          done();
+        });
+    });
+
+    it('hashes the password', async function () {
+      await request(app).post('/v1/auth/signup').send({
+        email: 'hash@example.com',
+        password: 'password123',
+        firstName: 'Hash',
+      });
+
+      const user = await User.findOne({ where: { email: 'hash@example.com' } });
+      assert.exists(user?.passwordHash);
+      assert.notEqual(user!.passwordHash, 'password123');
+      const matches = await bcrypt.compare('password123', user!.passwordHash!);
+      assert.isTrue(matches);
+    });
+
+    it('returns 409 if email already exists', async function () {
+      await request(app).post('/v1/auth/signup').send({
+        email: 'dupe@example.com',
+        password: 'password123',
+        firstName: 'First',
+      });
+
+      const res = await request(app).post('/v1/auth/signup').send({
+        email: 'dupe@example.com',
+        password: 'password456',
+        firstName: 'Second',
+      });
+
+      assert.equal(res.status, 409);
+    });
+
+    it('returns 400 if required fields are missing', async function () {
+      const res = await request(app).post('/v1/auth/signup').send({ email: 'test@example.com' });
+
+      assert.equal(res.status, 400);
+    });
+  });
+
+  describe('POST /v1/auth/login', function () {
+    beforeEach(async function () {
+      const passwordHash = await bcrypt.hash('password123', 10);
+      await User.create({
+        email: 'login@example.com',
+        firstName: 'Login',
+        lastName: 'User',
+        passwordHash,
+      });
+    });
+
+    it('logs in with correct credentials', function (done) {
+      request(app)
+        .post('/v1/auth/login')
+        .send({ email: 'login@example.com', password: 'password123' })
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+          assert.exists(res.body.token);
+          assert.equal(res.body.user.email, 'login@example.com');
+          assert.equal(res.body.user.firstName, 'Login');
+          done();
+        });
+    });
+
+    it('returns 401 for wrong password', async function () {
+      const res = await request(app)
+        .post('/v1/auth/login')
+        .send({ email: 'login@example.com', password: 'wrongpassword' });
+
+      assert.equal(res.status, 401);
+    });
+
+    it('returns 401 for non-existent email', async function () {
+      const res = await request(app)
+        .post('/v1/auth/login')
+        .send({ email: 'nobody@example.com', password: 'password123' });
+
+      assert.equal(res.status, 401);
+    });
+
+    it('returns 400 if required fields are missing', async function () {
+      const res = await request(app).post('/v1/auth/login').send({ email: 'login@example.com' });
+
+      assert.equal(res.status, 400);
+    });
+  });
+
+  describe('POST /v1/auth/google', function () {
+    const originalGoogleClientId = config.GOOGLE_CLIENT_ID;
+
+    beforeEach(function () {
+      config.GOOGLE_CLIENT_ID = 'test-google-client-id';
+    });
+
+    afterEach(function () {
+      config.GOOGLE_CLIENT_ID = originalGoogleClientId;
+      sinon.restore();
+    });
+
+    it('creates a new user from Google token', async function () {
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
+        mockTicket({
+          email: 'google@example.com',
+          email_verified: true,
+          given_name: 'Google',
+          family_name: 'User',
+          picture: 'https://example.com/photo.jpg',
+          sub: 'google-user-id-123',
+          aud: 'test-google-client-id',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          iat: Math.floor(Date.now() / 1000),
+          iss: 'accounts.google.com',
+        }),
+      );
+
+      const res = await request(app)
+        .post('/v1/auth/google')
+        .send({ idToken: 'valid-google-token' });
+
+      assert.equal(res.status, 200);
+      assert.exists(res.body.token);
+      assert.equal(res.body.user.email, 'google@example.com');
+      assert.equal(res.body.user.firstName, 'Google');
+      assert.equal(res.body.user.lastName, 'User');
+    });
+
+    it('logs in existing user with matching email', async function () {
+      await User.create({
+        email: 'existing@example.com',
+        firstName: 'Existing',
+        lastName: 'User',
+      });
+
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
+        mockTicket({
+          email: 'existing@example.com',
+          email_verified: true,
+          given_name: 'Existing',
+          family_name: 'User',
+          sub: 'google-user-id-456',
+          aud: 'test-google-client-id',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          iat: Math.floor(Date.now() / 1000),
+          iss: 'accounts.google.com',
+        }),
+      );
+
+      const res = await request(app)
+        .post('/v1/auth/google')
+        .send({ idToken: 'valid-google-token' });
+
+      assert.equal(res.status, 200);
+      assert.exists(res.body.token);
+      assert.equal(res.body.user.email, 'existing@example.com');
+
+      const users = await User.findAll({
+        where: { email: 'existing@example.com' },
+      });
+      assert.equal(users.length, 1);
+    });
+
+    it('returns 400 if GOOGLE_CLIENT_ID is not set', async function () {
+      config.GOOGLE_CLIENT_ID = undefined;
+
+      const res = await request(app).post('/v1/auth/google').send({ idToken: 'some-token' });
+
+      assert.equal(res.status, 400);
+    });
+
+    it('returns 401 for invalid token', async function () {
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').rejects(new Error('Invalid token'));
+
+      const res = await request(app).post('/v1/auth/google').send({ idToken: 'invalid-token' });
+
+      assert.equal(res.status, 401);
+    });
+
+    it('returns 400 if idToken is missing', async function () {
+      const res = await request(app).post('/v1/auth/google').send({});
+
+      assert.equal(res.status, 400);
+    });
+  });
+});

--- a/server/src/api/auth/auth.api.test.ts
+++ b/server/src/api/auth/auth.api.test.ts
@@ -1,132 +1,136 @@
-import { assert } from 'chai';
-import * as sinon from 'sinon';
-import request from 'supertest';
-import * as bcrypt from 'bcrypt';
-import { LoginTicket, OAuth2Client, TokenPayload } from 'google-auth-library';
-import app from '../../server';
-import User from '../../db/models/user.model';
-import config from '../../config/config';
+import { assert } from "chai";
+import * as sinon from "sinon";
+import request from "supertest";
+import * as bcrypt from "bcrypt";
+import { LoginTicket, OAuth2Client, TokenPayload } from "google-auth-library";
+import app from "../../server";
+import User from "../../db/models/user.model";
+import config from "../../config/config";
 
 function mockTicket(payload: TokenPayload): LoginTicket {
   const ticket = new LoginTicket();
-  sinon.stub(ticket, 'getPayload').returns(payload);
+  sinon.stub(ticket, "getPayload").returns(payload);
   return ticket;
 }
 
-describe('Auth API', function () {
-  describe('POST /v1/auth/signup', function () {
-    it('creates a new user and returns a token', function (done) {
+describe("Auth API", function () {
+  describe("POST /v1/auth/signup", function () {
+    it("creates a new user and returns a token", function (done) {
       request(app)
-        .post('/v1/auth/signup')
+        .post("/v1/auth/signup")
         .send({
-          email: 'test@example.com',
-          password: 'password123',
-          firstName: 'Test',
-          lastName: 'User',
+          email: "test@example.com",
+          password: "password123",
+          firstName: "Test",
+          lastName: "User",
         })
         .expect(201)
         .end(function (err, res) {
           if (err) return done(err);
           assert.exists(res.body.token);
-          assert.equal(res.body.user.email, 'test@example.com');
-          assert.equal(res.body.user.firstName, 'Test');
-          assert.equal(res.body.user.lastName, 'User');
-          assert.equal(res.body.user.role, 'user');
+          assert.equal(res.body.user.email, "test@example.com");
+          assert.equal(res.body.user.firstName, "Test");
+          assert.equal(res.body.user.lastName, "User");
+          assert.equal(res.body.user.role, "user");
           assert.exists(res.body.user.id);
           done();
         });
     });
 
-    it('hashes the password', async function () {
-      await request(app).post('/v1/auth/signup').send({
-        email: 'hash@example.com',
-        password: 'password123',
-        firstName: 'Hash',
+    it("hashes the password", async function () {
+      await request(app).post("/v1/auth/signup").send({
+        email: "hash@example.com",
+        password: "password123",
+        firstName: "Hash",
       });
 
-      const user = await User.findOne({ where: { email: 'hash@example.com' } });
+      const user = await User.findOne({ where: { email: "hash@example.com" } });
       assert.exists(user?.passwordHash);
-      assert.notEqual(user!.passwordHash, 'password123');
-      const matches = await bcrypt.compare('password123', user!.passwordHash!);
+      assert.notEqual(user!.passwordHash, "password123");
+      const matches = await bcrypt.compare("password123", user!.passwordHash!);
       assert.isTrue(matches);
     });
 
-    it('returns 409 if email already exists', async function () {
-      await request(app).post('/v1/auth/signup').send({
-        email: 'dupe@example.com',
-        password: 'password123',
-        firstName: 'First',
+    it("returns 409 if email already exists", async function () {
+      await request(app).post("/v1/auth/signup").send({
+        email: "dupe@example.com",
+        password: "password123",
+        firstName: "First",
       });
 
-      const res = await request(app).post('/v1/auth/signup').send({
-        email: 'dupe@example.com',
-        password: 'password456',
-        firstName: 'Second',
+      const res = await request(app).post("/v1/auth/signup").send({
+        email: "dupe@example.com",
+        password: "password456",
+        firstName: "Second",
       });
 
       assert.equal(res.status, 409);
     });
 
-    it('returns 400 if required fields are missing', async function () {
-      const res = await request(app).post('/v1/auth/signup').send({ email: 'test@example.com' });
+    it("returns 400 if required fields are missing", async function () {
+      const res = await request(app)
+        .post("/v1/auth/signup")
+        .send({ email: "test@example.com" });
 
       assert.equal(res.status, 400);
     });
   });
 
-  describe('POST /v1/auth/login', function () {
+  describe("POST /v1/auth/login", function () {
     beforeEach(async function () {
-      const passwordHash = await bcrypt.hash('password123', 10);
+      const passwordHash = await bcrypt.hash("password123", 10);
       await User.create({
-        email: 'login@example.com',
-        firstName: 'Login',
-        lastName: 'User',
+        email: "login@example.com",
+        firstName: "Login",
+        lastName: "User",
         passwordHash,
       });
     });
 
-    it('logs in with correct credentials', function (done) {
+    it("logs in with correct credentials", function (done) {
       request(app)
-        .post('/v1/auth/login')
-        .send({ email: 'login@example.com', password: 'password123' })
+        .post("/v1/auth/login")
+        .send({ email: "login@example.com", password: "password123" })
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err);
           assert.exists(res.body.token);
-          assert.equal(res.body.user.email, 'login@example.com');
-          assert.equal(res.body.user.firstName, 'Login');
+          assert.equal(res.body.user.email, "login@example.com");
+          assert.equal(res.body.user.firstName, "Login");
           done();
         });
     });
 
-    it('returns 401 for wrong password', async function () {
+    it("returns 401 for wrong password", async function () {
       const res = await request(app)
-        .post('/v1/auth/login')
-        .send({ email: 'login@example.com', password: 'wrongpassword' });
+        .post("/v1/auth/login")
+        .send({ email: "login@example.com", password: "wrongpassword" });
 
       assert.equal(res.status, 401);
     });
 
-    it('returns 401 for non-existent email', async function () {
+    it("returns 401 for non-existent email", async function () {
       const res = await request(app)
-        .post('/v1/auth/login')
-        .send({ email: 'nobody@example.com', password: 'password123' });
+        .post("/v1/auth/login")
+        .send({ email: "nobody@example.com", password: "password123" });
 
       assert.equal(res.status, 401);
     });
 
-    it('returns 400 if required fields are missing', async function () {
-      const res = await request(app).post('/v1/auth/login').send({ email: 'login@example.com' });
+    it("returns 400 if required fields are missing", async function () {
+      const res = await request(app)
+        .post("/v1/auth/login")
+        .send({ email: "login@example.com" });
 
       assert.equal(res.status, 400);
     });
   });
 
-  describe('POST /v1/auth/google', function () {
+  describe("POST /v1/auth/google", function () {
     const originalGoogleClientId = config.GOOGLE_CLIENT_ID;
 
     beforeEach(function () {
-      config.GOOGLE_CLIENT_ID = 'test-google-client-id';
+      config.GOOGLE_CLIENT_ID = "test-google-client-id";
     });
 
     afterEach(function () {
@@ -134,86 +138,92 @@ describe('Auth API', function () {
       sinon.restore();
     });
 
-    it('creates a new user from Google token', async function () {
-      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
+    it("creates a new user from Google token", async function () {
+      sinon.stub(OAuth2Client.prototype, "verifyIdToken").resolves(
         mockTicket({
-          email: 'google@example.com',
+          email: "google@example.com",
           email_verified: true,
-          given_name: 'Google',
-          family_name: 'User',
-          picture: 'https://example.com/photo.jpg',
-          sub: 'google-user-id-123',
-          aud: 'test-google-client-id',
+          given_name: "Google",
+          family_name: "User",
+          picture: "https://example.com/photo.jpg",
+          sub: "google-user-id-123",
+          aud: "test-google-client-id",
           exp: Math.floor(Date.now() / 1000) + 3600,
           iat: Math.floor(Date.now() / 1000),
-          iss: 'accounts.google.com',
+          iss: "accounts.google.com",
         }),
       );
 
       const res = await request(app)
-        .post('/v1/auth/google')
-        .send({ idToken: 'valid-google-token' });
+        .post("/v1/auth/google")
+        .send({ idToken: "valid-google-token" });
 
       assert.equal(res.status, 200);
       assert.exists(res.body.token);
-      assert.equal(res.body.user.email, 'google@example.com');
-      assert.equal(res.body.user.firstName, 'Google');
-      assert.equal(res.body.user.lastName, 'User');
+      assert.equal(res.body.user.email, "google@example.com");
+      assert.equal(res.body.user.firstName, "Google");
+      assert.equal(res.body.user.lastName, "User");
     });
 
-    it('logs in existing user with matching email', async function () {
+    it("logs in existing user with matching email", async function () {
       await User.create({
-        email: 'existing@example.com',
-        firstName: 'Existing',
-        lastName: 'User',
+        email: "existing@example.com",
+        firstName: "Existing",
+        lastName: "User",
       });
 
-      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
+      sinon.stub(OAuth2Client.prototype, "verifyIdToken").resolves(
         mockTicket({
-          email: 'existing@example.com',
+          email: "existing@example.com",
           email_verified: true,
-          given_name: 'Existing',
-          family_name: 'User',
-          sub: 'google-user-id-456',
-          aud: 'test-google-client-id',
+          given_name: "Existing",
+          family_name: "User",
+          sub: "google-user-id-456",
+          aud: "test-google-client-id",
           exp: Math.floor(Date.now() / 1000) + 3600,
           iat: Math.floor(Date.now() / 1000),
-          iss: 'accounts.google.com',
+          iss: "accounts.google.com",
         }),
       );
 
       const res = await request(app)
-        .post('/v1/auth/google')
-        .send({ idToken: 'valid-google-token' });
+        .post("/v1/auth/google")
+        .send({ idToken: "valid-google-token" });
 
       assert.equal(res.status, 200);
       assert.exists(res.body.token);
-      assert.equal(res.body.user.email, 'existing@example.com');
+      assert.equal(res.body.user.email, "existing@example.com");
 
       const users = await User.findAll({
-        where: { email: 'existing@example.com' },
+        where: { email: "existing@example.com" },
       });
       assert.equal(users.length, 1);
     });
 
-    it('returns 400 if GOOGLE_CLIENT_ID is not set', async function () {
+    it("returns 400 if GOOGLE_CLIENT_ID is not set", async function () {
       config.GOOGLE_CLIENT_ID = undefined;
 
-      const res = await request(app).post('/v1/auth/google').send({ idToken: 'some-token' });
+      const res = await request(app)
+        .post("/v1/auth/google")
+        .send({ idToken: "some-token" });
 
       assert.equal(res.status, 400);
     });
 
-    it('returns 401 for invalid token', async function () {
-      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').rejects(new Error('Invalid token'));
+    it("returns 401 for invalid token", async function () {
+      sinon
+        .stub(OAuth2Client.prototype, "verifyIdToken")
+        .rejects(new Error("Invalid token"));
 
-      const res = await request(app).post('/v1/auth/google').send({ idToken: 'invalid-token' });
+      const res = await request(app)
+        .post("/v1/auth/google")
+        .send({ idToken: "invalid-token" });
 
       assert.equal(res.status, 401);
     });
 
-    it('returns 400 if idToken is missing', async function () {
-      const res = await request(app).post('/v1/auth/google').send({});
+    it("returns 400 if idToken is missing", async function () {
+      const res = await request(app).post("/v1/auth/google").send({});
 
       assert.equal(res.status, 400);
     });

--- a/server/src/api/auth/auth.api.ts
+++ b/server/src/api/auth/auth.api.ts
@@ -1,0 +1,37 @@
+import { NextFunction, Request, Response } from 'express';
+import { googleSignIn, login, signup } from '../../lib/auth';
+
+export async function handleSignup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password, firstName, lastName } = req.body;
+    const { user, token } = await signup({
+      email,
+      password,
+      firstName,
+      lastName,
+    });
+    res.status(201).json({ user: user.jwtRepr(), token });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleLogin(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password } = req.body;
+    const { user, token } = await login({ email, password });
+    res.status(200).json({ user: user.jwtRepr(), token });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleGoogleSignIn(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { idToken } = req.body;
+    const { user, token } = await googleSignIn({ idToken });
+    res.status(200).json({ user: user.jwtRepr(), token });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/server/src/api/auth/auth.api.ts
+++ b/server/src/api/auth/auth.api.ts
@@ -1,7 +1,11 @@
-import { NextFunction, Request, Response } from 'express';
-import { googleSignIn, login, signup } from '../../lib/auth';
+import { NextFunction, Request, Response } from "express";
+import { googleSignIn, login, signup } from "../../lib/auth";
 
-export async function handleSignup(req: Request, res: Response, next: NextFunction) {
+export async function handleSignup(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { email, password, firstName, lastName } = req.body;
     const { user, token } = await signup({
@@ -16,7 +20,11 @@ export async function handleSignup(req: Request, res: Response, next: NextFuncti
   }
 }
 
-export async function handleLogin(req: Request, res: Response, next: NextFunction) {
+export async function handleLogin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { email, password } = req.body;
     const { user, token } = await login({ email, password });
@@ -26,7 +34,11 @@ export async function handleLogin(req: Request, res: Response, next: NextFunctio
   }
 }
 
-export async function handleGoogleSignIn(req: Request, res: Response, next: NextFunction) {
+export async function handleGoogleSignIn(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { idToken } = req.body;
     const { user, token } = await googleSignIn({ idToken });

--- a/server/src/api/auth/index.ts
+++ b/server/src/api/auth/index.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { checkBodyFor } from '../validation';
+import { handleGoogleSignIn, handleLogin, handleSignup } from './auth.api';
+
+const router = express.Router();
+
+router.post('/signup', checkBodyFor(['email', 'password', 'firstName']), handleSignup);
+
+router.post('/login', checkBodyFor(['email', 'password']), handleLogin);
+
+router.post('/google', checkBodyFor(['idToken']), handleGoogleSignIn);
+
+export default router;

--- a/server/src/api/auth/index.ts
+++ b/server/src/api/auth/index.ts
@@ -1,13 +1,17 @@
-import express from 'express';
-import { checkBodyFor } from '../validation';
-import { handleGoogleSignIn, handleLogin, handleSignup } from './auth.api';
+import express from "express";
+import { checkBodyFor } from "../validation";
+import { handleGoogleSignIn, handleLogin, handleSignup } from "./auth.api";
 
 const router = express.Router();
 
-router.post('/signup', checkBodyFor(['email', 'password', 'firstName']), handleSignup);
+router.post(
+  "/signup",
+  checkBodyFor(["email", "password", "firstName"]),
+  handleSignup,
+);
 
-router.post('/login', checkBodyFor(['email', 'password']), handleLogin);
+router.post("/login", checkBodyFor(["email", "password"]), handleLogin);
 
-router.post('/google', checkBodyFor(['idToken']), handleGoogleSignIn);
+router.post("/google", checkBodyFor(["idToken"]), handleGoogleSignIn);
 
 export default router;

--- a/server/src/api/routes.ts
+++ b/server/src/api/routes.ts
@@ -1,10 +1,10 @@
-import { Application } from 'express';
-import authApi from './auth';
-import healthCheckApi from './healthCheck';
+import { Application } from "express";
+import authApi from "./auth";
+import healthCheckApi from "./healthCheck";
 
 function addRoutes(app: Application) {
-  app.use('/v1/auth', authApi);
-  app.use('/v1/healthCheck', healthCheckApi);
+  app.use("/v1/auth", authApi);
+  app.use("/v1/healthCheck", healthCheckApi);
 }
 
 export default addRoutes;

--- a/server/src/api/routes.ts
+++ b/server/src/api/routes.ts
@@ -1,8 +1,10 @@
-import { Application } from "express";
-import healthCheckApi from "./healthCheck";
+import { Application } from 'express';
+import authApi from './auth';
+import healthCheckApi from './healthCheck';
 
 function addRoutes(app: Application) {
-  app.use("/v1/healthCheck", healthCheckApi);
+  app.use('/v1/auth', authApi);
+  app.use('/v1/healthCheck', healthCheckApi);
 }
 
 export default addRoutes;

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -1,9 +1,9 @@
-import { optionalEnvVars, requiredEnvVars } from "./envVars";
+import { optionalEnvVars, requiredEnvVars } from './envVars';
 
 export enum Environments {
-  PRODUCTION = "production",
-  DEVELOPMENT = "development",
-  TEST = "test",
+  PRODUCTION = 'production',
+  DEVELOPMENT = 'development',
+  TEST = 'test',
 }
 
 type EnvVars = {
@@ -26,6 +26,10 @@ export class Config implements Partial<EnvVars> {
   _BASIC_AUTH_TOKENS?: string;
   REDIS_URL?: string;
   _REDIS_URL?: string;
+  GOOGLE_CLIENT_ID?: string;
+  _GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  _GOOGLE_CLIENT_SECRET?: string;
 
   constructor(env: string = process.env.NODE_ENV ?? Environments.DEVELOPMENT) {
     this.env = env;
@@ -35,11 +39,11 @@ export class Config implements Partial<EnvVars> {
   get BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return "https://your-production-client-url.com";
+        return 'https://your-production-client-url.com';
       case Environments.DEVELOPMENT:
-        return "http://localhost:10020";
+        return 'http://localhost:10020';
       case Environments.TEST:
-        return "http://localhost:10021";
+        return 'http://localhost:10021';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -48,11 +52,11 @@ export class Config implements Partial<EnvVars> {
   get CLIENT_BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return "https://your-production-server-url.com";
+        return 'https://your-production-server-url.com';
       case Environments.DEVELOPMENT:
-        return "http://localhost:3000";
+        return 'http://localhost:3000';
       case Environments.TEST:
-        return "http://localhost:3001";
+        return 'http://localhost:3001';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -62,9 +66,9 @@ export class Config implements Partial<EnvVars> {
     switch (this.env) {
       case Environments.DEVELOPMENT:
       case Environments.TEST:
-        return "http://localhost:10020/v1/auth/google/web/authorize";
+        return 'http://localhost:10020/v1/auth/google/web/authorize';
       case Environments.PRODUCTION: // google does not allow testing from localhost!
-        return "https://your-production-url/v1/auth/google/web/authorize";
+        return 'https://your-production-url/v1/auth/google/web/authorize';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -1,9 +1,9 @@
-import { optionalEnvVars, requiredEnvVars } from './envVars';
+import { optionalEnvVars, requiredEnvVars } from "./envVars";
 
 export enum Environments {
-  PRODUCTION = 'production',
-  DEVELOPMENT = 'development',
-  TEST = 'test',
+  PRODUCTION = "production",
+  DEVELOPMENT = "development",
+  TEST = "test",
 }
 
 type EnvVars = {
@@ -39,11 +39,11 @@ export class Config implements Partial<EnvVars> {
   get BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return 'https://your-production-client-url.com';
+        return "https://your-production-client-url.com";
       case Environments.DEVELOPMENT:
-        return 'http://localhost:10020';
+        return "http://localhost:10020";
       case Environments.TEST:
-        return 'http://localhost:10021';
+        return "http://localhost:10021";
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -52,11 +52,11 @@ export class Config implements Partial<EnvVars> {
   get CLIENT_BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return 'https://your-production-server-url.com';
+        return "https://your-production-server-url.com";
       case Environments.DEVELOPMENT:
-        return 'http://localhost:3000';
+        return "http://localhost:3000";
       case Environments.TEST:
-        return 'http://localhost:3001';
+        return "http://localhost:3001";
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -66,9 +66,9 @@ export class Config implements Partial<EnvVars> {
     switch (this.env) {
       case Environments.DEVELOPMENT:
       case Environments.TEST:
-        return 'http://localhost:10020/v1/auth/google/web/authorize';
+        return "http://localhost:10020/v1/auth/google/web/authorize";
       case Environments.PRODUCTION: // google does not allow testing from localhost!
-        return 'https://your-production-url/v1/auth/google/web/authorize';
+        return "https://your-production-url/v1/auth/google/web/authorize";
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }

--- a/server/src/config/envVars.ts
+++ b/server/src/config/envVars.ts
@@ -1,11 +1,16 @@
-export const requiredEnvVars = ['NODE_ENV', 'PORT', 'DATABASE_URL', 'JWT_SECRET'] as const;
+export const requiredEnvVars = [
+  "NODE_ENV",
+  "PORT",
+  "DATABASE_URL",
+  "JWT_SECRET",
+] as const;
 
 export const optionalEnvVars = [
-  'SOME_OPTIONAL_ENV_VARIABLE',
-  'BASIC_AUTH_TOKENS',
-  'REDIS_URL',
-  'GOOGLE_CLIENT_ID',
-  'GOOGLE_CLIENT_SECRET',
+  "SOME_OPTIONAL_ENV_VARIABLE",
+  "BASIC_AUTH_TOKENS",
+  "REDIS_URL",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
 ] as const;
 
 export type RequiredEnvVar = (typeof requiredEnvVars)[number];

--- a/server/src/config/envVars.ts
+++ b/server/src/config/envVars.ts
@@ -1,14 +1,11 @@
-export const requiredEnvVars = [
-  "NODE_ENV",
-  "PORT",
-  "DATABASE_URL",
-  "JWT_SECRET",
-] as const;
+export const requiredEnvVars = ['NODE_ENV', 'PORT', 'DATABASE_URL', 'JWT_SECRET'] as const;
 
 export const optionalEnvVars = [
-  "SOME_OPTIONAL_ENV_VARIABLE",
-  "BASIC_AUTH_TOKENS",
-  "REDIS_URL",
+  'SOME_OPTIONAL_ENV_VARIABLE',
+  'BASIC_AUTH_TOKENS',
+  'REDIS_URL',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
 ] as const;
 
 export type RequiredEnvVar = (typeof requiredEnvVars)[number];

--- a/server/src/db/models/user.model/user.model.ts
+++ b/server/src/db/models/user.model/user.model.ts
@@ -4,8 +4,8 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
-} from 'sequelize';
-import sequelize from '../../sequelize';
+} from "sequelize";
+import sequelize from "../../sequelize";
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare id: CreationOptional<string>;
@@ -16,7 +16,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare verifiedEmail: CreationOptional<string>;
   declare passwordHash: CreationOptional<string>;
   declare profileImageUrl: CreationOptional<string>;
-  declare role: CreationOptional<'admin' | 'user' | 'guest'>;
+  declare role: CreationOptional<"admin" | "user" | "guest">;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -57,16 +57,16 @@ User.init(
     passwordHash: DataTypes.STRING,
     profileImageUrl: DataTypes.STRING,
     role: {
-      type: DataTypes.ENUM('admin', 'user', 'guest'),
+      type: DataTypes.ENUM("admin", "user", "guest"),
       allowNull: false,
-      defaultValue: 'user',
+      defaultValue: "user",
     },
     createdAt: DataTypes.DATE,
     updatedAt: DataTypes.DATE,
   },
   {
     sequelize,
-    modelName: 'user',
+    modelName: "user",
   },
 );
 

--- a/server/src/db/models/user.model/user.model.ts
+++ b/server/src/db/models/user.model/user.model.ts
@@ -4,8 +4,8 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
-} from "sequelize";
-import sequelize from "../../sequelize";
+} from 'sequelize';
+import sequelize from '../../sequelize';
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare id: CreationOptional<string>;
@@ -16,7 +16,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare verifiedEmail: CreationOptional<string>;
   declare passwordHash: CreationOptional<string>;
   declare profileImageUrl: CreationOptional<string>;
-  declare role: "admin" | "user" | "guest";
+  declare role: CreationOptional<'admin' | 'user' | 'guest'>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -57,16 +57,16 @@ User.init(
     passwordHash: DataTypes.STRING,
     profileImageUrl: DataTypes.STRING,
     role: {
-      type: DataTypes.ENUM("admin", "user", "guest"),
+      type: DataTypes.ENUM('admin', 'user', 'guest'),
       allowNull: false,
-      defaultValue: "user",
+      defaultValue: 'user',
     },
     createdAt: DataTypes.DATE,
     updatedAt: DataTypes.DATE,
   },
   {
     sequelize,
-    modelName: "user",
+    modelName: 'user',
   },
 );
 

--- a/server/src/lib/auth/auth.lib.ts
+++ b/server/src/lib/auth/auth.lib.ts
@@ -1,0 +1,102 @@
+import * as bcrypt from 'bcrypt';
+import { OAuth2Client } from 'google-auth-library';
+import config from '../../config/config';
+import User from '../../db/models/user.model';
+import { AuthenticationError, ConflictError, ValidationError } from '../../utils/errors';
+import { generateToken } from '../../utils/jwt';
+
+const SALT_ROUNDS = 10;
+
+export async function signup({
+  email,
+  password,
+  firstName,
+  lastName,
+}: {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName?: string;
+}): Promise<{ user: User; token: string }> {
+  const existing = await User.findOne({ where: { email } });
+  if (existing) {
+    throw new ConflictError('A user with this email already exists');
+  }
+
+  const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+  const user = await User.create({
+    email,
+    firstName,
+    lastName: lastName ?? '',
+    passwordHash,
+  });
+
+  const token = await generateToken(user);
+  return { user, token };
+}
+
+export async function login({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}): Promise<{ user: User; token: string }> {
+  const user = await User.findOne({ where: { email } });
+  if (!user || !user.passwordHash) {
+    throw new AuthenticationError('Invalid email or password');
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    throw new AuthenticationError('Invalid email or password');
+  }
+
+  const token = await generateToken(user);
+  return { user, token };
+}
+
+export async function googleSignIn({
+  idToken,
+}: {
+  idToken: string;
+}): Promise<{ user: User; token: string }> {
+  if (!config.GOOGLE_CLIENT_ID) {
+    throw new ValidationError('Google sign-in is not configured');
+  }
+
+  const client = new OAuth2Client(config.GOOGLE_CLIENT_ID);
+  let payload;
+  try {
+    const ticket = await client.verifyIdToken({
+      idToken,
+      audience: config.GOOGLE_CLIENT_ID,
+    });
+    payload = ticket.getPayload();
+  } catch {
+    throw new AuthenticationError('Invalid Google ID token');
+  }
+
+  if (!payload || !payload.email) {
+    throw new AuthenticationError('Invalid Google ID token');
+  }
+
+  let user = await User.findOne({ where: { email: payload.email } });
+
+  if (user) {
+    if (!user.verifiedEmail && payload.email_verified) {
+      await user.update({ verifiedEmail: payload.email });
+    }
+  } else {
+    user = await User.create({
+      email: payload.email,
+      firstName: payload.given_name ?? payload.email.split('@')[0],
+      lastName: payload.family_name ?? '',
+      verifiedEmail: payload.email_verified ? payload.email : undefined,
+      profileImageUrl: payload.picture,
+    });
+  }
+
+  const token = await generateToken(user);
+  return { user, token };
+}

--- a/server/src/lib/auth/auth.lib.ts
+++ b/server/src/lib/auth/auth.lib.ts
@@ -1,9 +1,13 @@
-import * as bcrypt from 'bcrypt';
-import { OAuth2Client } from 'google-auth-library';
-import config from '../../config/config';
-import User from '../../db/models/user.model';
-import { AuthenticationError, ConflictError, ValidationError } from '../../utils/errors';
-import { generateToken } from '../../utils/jwt';
+import * as bcrypt from "bcrypt";
+import { OAuth2Client } from "google-auth-library";
+import config from "../../config/config";
+import User from "../../db/models/user.model";
+import {
+  AuthenticationError,
+  ConflictError,
+  ValidationError,
+} from "../../utils/errors";
+import { generateToken } from "../../utils/jwt";
 
 const SALT_ROUNDS = 10;
 
@@ -20,14 +24,14 @@ export async function signup({
 }): Promise<{ user: User; token: string }> {
   const existing = await User.findOne({ where: { email } });
   if (existing) {
-    throw new ConflictError('A user with this email already exists');
+    throw new ConflictError("A user with this email already exists");
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
   const user = await User.create({
     email,
     firstName,
-    lastName: lastName ?? '',
+    lastName: lastName ?? "",
     passwordHash,
   });
 
@@ -44,12 +48,12 @@ export async function login({
 }): Promise<{ user: User; token: string }> {
   const user = await User.findOne({ where: { email } });
   if (!user || !user.passwordHash) {
-    throw new AuthenticationError('Invalid email or password');
+    throw new AuthenticationError("Invalid email or password");
   }
 
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) {
-    throw new AuthenticationError('Invalid email or password');
+    throw new AuthenticationError("Invalid email or password");
   }
 
   const token = await generateToken(user);
@@ -62,7 +66,7 @@ export async function googleSignIn({
   idToken: string;
 }): Promise<{ user: User; token: string }> {
   if (!config.GOOGLE_CLIENT_ID) {
-    throw new ValidationError('Google sign-in is not configured');
+    throw new ValidationError("Google sign-in is not configured");
   }
 
   const client = new OAuth2Client(config.GOOGLE_CLIENT_ID);
@@ -74,11 +78,11 @@ export async function googleSignIn({
     });
     payload = ticket.getPayload();
   } catch {
-    throw new AuthenticationError('Invalid Google ID token');
+    throw new AuthenticationError("Invalid Google ID token");
   }
 
   if (!payload || !payload.email) {
-    throw new AuthenticationError('Invalid Google ID token');
+    throw new AuthenticationError("Invalid Google ID token");
   }
 
   let user = await User.findOne({ where: { email: payload.email } });
@@ -90,8 +94,8 @@ export async function googleSignIn({
   } else {
     user = await User.create({
       email: payload.email,
-      firstName: payload.given_name ?? payload.email.split('@')[0],
-      lastName: payload.family_name ?? '',
+      firstName: payload.given_name ?? payload.email.split("@")[0],
+      lastName: payload.family_name ?? "",
       verifiedEmail: payload.email_verified ? payload.email : undefined,
       profileImageUrl: payload.picture,
     });

--- a/server/src/lib/auth/index.ts
+++ b/server/src/lib/auth/index.ts
@@ -1,0 +1,1 @@
+export { signup, login, googleSignIn } from './auth.lib';

--- a/server/src/lib/auth/index.ts
+++ b/server/src/lib/auth/index.ts
@@ -1,1 +1,1 @@
-export { signup, login, googleSignIn } from './auth.lib';
+export { signup, login, googleSignIn } from "./auth.lib";


### PR DESCRIPTION
## Summary
- **POST /v1/auth/signup**: Hash password with bcrypt, create user, return JWT
- **POST /v1/auth/login**: Verify password against hash, return JWT
- **POST /v1/auth/google**: Exchange Google ID token for JWT (only available when `GOOGLE_CLIENT_ID` env var is set)
- Auth business logic in `server/src/lib/auth/`, API handlers in `server/src/api/auth/`
- 13 integration tests covering success paths, validation errors, and auth failures
- OpenAPI docs for all three endpoints

## Changes
- Add `bcrypt`, `@types/bcrypt`, `google-auth-library` dependencies
- Add `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` as optional env vars in config
- Fix User model `role` field to be `CreationOptional` (has `defaultValue`)
- Register auth routes in `routes.ts`

## Test plan
- [x] All 63 tests pass (13 new auth tests + 50 existing)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Signup creates user with hashed password and returns JWT
- [x] Signup returns 409 for duplicate email
- [x] Login returns JWT for valid credentials, 401 for invalid
- [x] Google endpoint returns 400 when GOOGLE_CLIENT_ID not configured
- [x] Google endpoint creates new user or logs in existing user by email match

🤖 Generated with [Claude Code](https://claude.com/claude-code)