### PR TITLE
Add client auth architecture with routing and pages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,8 +8,10 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.15.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -2387,7 +2389,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -2404,6 +2405,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2504,7 +2516,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2630,7 +2641,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2652,6 +2662,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2832,7 +2855,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2849,7 +2871,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2898,7 +2919,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2908,7 +2928,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2946,7 +2965,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2959,7 +2977,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3323,6 +3340,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3360,7 +3397,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3392,7 +3428,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3422,7 +3457,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3447,7 +3481,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3535,7 +3568,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3584,7 +3616,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3597,7 +3628,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3613,7 +3643,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4358,7 +4387,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4368,7 +4396,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4378,7 +4405,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4785,6 +4811,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -4855,6 +4890,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/redent": {
@@ -5017,6 +5090,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -13,8 +13,10 @@
     "prettier:write": "prettier --write ."
   },
   "dependencies": {
+    "axios": "^1.15.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,42 +1,90 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app-content {
+  flex: 1;
+  max-width: 800px;
+  width: 100%;
+  margin: 2rem auto;
+  padding: 0 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+/* Navbar */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid #333;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.navbar-brand {
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-.card {
-  padding: 2em;
+.navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
-.read-the-docs {
-  color: #888;
+.navbar-user {
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
+.navbar-logout {
+  padding: 0.3em 0.8em;
+  font-size: 0.85rem;
+}
+
+/* Auth pages */
+.auth-page {
+  max-width: 400px;
+  margin: 2rem auto;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auth-form label {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.auth-form input {
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background: inherit;
+  color: inherit;
+  font-size: 1rem;
+}
+
+.auth-form button {
+  margin-top: 1rem;
+}
+
+.auth-error {
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.1);
+  padding: 0.5rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+/* Dashboard */
+.dashboard-page {
+  margin: 1rem 0;
+}
+
+.user-info p {
+  margin: 0.5rem 0;
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,31 +1,14 @@
+import { Outlet } from "react-router-dom";
 import "./App.css";
-import reactLogo from "./assets/react.svg";
-import Counter from "./Components/Counter";
-import viteLogo from "/vite.svg";
+import Navbar from "./Components/Navbar/Navbar";
 
-function App() {
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <Counter />
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <Navbar />
+      <main className="app-content">
+        <Outlet />
+      </main>
+    </div>
   );
 }
-
-export default App;

--- a/client/src/Components/Navbar/Navbar.test.tsx
+++ b/client/src/Components/Navbar/Navbar.test.tsx
@@ -1,0 +1,17 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "../../test/testHelpers";
+import Navbar from "./Navbar";
+
+describe("Navbar", () => {
+  it("shows login and signup links when not authenticated", () => {
+    renderWithProviders(<Navbar />);
+    expect(screen.getByRole("link", { name: "Log In" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign Up" })).toBeInTheDocument();
+  });
+
+  it("shows app brand link", () => {
+    renderWithProviders(<Navbar />);
+    expect(screen.getByRole("link", { name: "App" })).toBeInTheDocument();
+  });
+});

--- a/client/src/Components/Navbar/Navbar.tsx
+++ b/client/src/Components/Navbar/Navbar.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../../Contexts/useAuth";
+
+export default function Navbar() {
+  const { isAuthenticated, user, logout } = useAuth();
+
+  return (
+    <nav className="navbar">
+      <Link to="/" className="navbar-brand">
+        App
+      </Link>
+      <div className="navbar-links">
+        {isAuthenticated ? (
+          <>
+            <Link to="/dashboard">Dashboard</Link>
+            <span className="navbar-user">
+              {user?.displayName || user?.email}
+            </span>
+            <button onClick={logout} className="navbar-logout">
+              Log Out
+            </button>
+          </>
+        ) : (
+          <>
+            <Link to="/login">Log In</Link>
+            <Link to="/signup">Sign Up</Link>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/client/src/Contexts/AuthProvider.tsx
+++ b/client/src/Contexts/AuthProvider.tsx
@@ -1,0 +1,96 @@
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import * as authService from "../Services/authService";
+import type {
+  AuthResponse,
+  LoginParams,
+  SignupParams,
+} from "../Services/authService";
+import { AuthContext, AuthUser } from "./authContext";
+
+function loadStoredAuth(): { user: AuthUser | null; token: string | null } {
+  const token = localStorage.getItem("token");
+  const userJson = localStorage.getItem("user");
+  if (token && userJson) {
+    try {
+      return { user: JSON.parse(userJson), token };
+    } catch {
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+    }
+  }
+  return { user: null, token: null };
+}
+
+function saveAuth(response: AuthResponse) {
+  localStorage.setItem("token", response.token);
+  localStorage.setItem("user", JSON.stringify(response.user));
+}
+
+function clearAuth() {
+  localStorage.removeItem("token");
+  localStorage.removeItem("user");
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const stored = loadStoredAuth();
+    setUser(stored.user);
+    setToken(stored.token);
+    setLoading(false);
+  }, []);
+
+  const handleAuthResponse = useCallback((response: AuthResponse) => {
+    saveAuth(response);
+    setUser(response.user);
+    setToken(response.token);
+  }, []);
+
+  const login = useCallback(
+    async (params: LoginParams) => {
+      const response = await authService.login(params);
+      handleAuthResponse(response);
+    },
+    [handleAuthResponse],
+  );
+
+  const signup = useCallback(
+    async (params: SignupParams) => {
+      const response = await authService.signup(params);
+      handleAuthResponse(response);
+    },
+    [handleAuthResponse],
+  );
+
+  const loginWithToken = useCallback((newToken: string, newUser: AuthUser) => {
+    localStorage.setItem("token", newToken);
+    localStorage.setItem("user", JSON.stringify(newUser));
+    setToken(newToken);
+    setUser(newUser);
+  }, []);
+
+  const logout = useCallback(() => {
+    clearAuth();
+    setUser(null);
+    setToken(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      isAuthenticated: !!token,
+      loading,
+      login,
+      signup,
+      loginWithToken,
+      logout,
+    }),
+    [user, token, loading, login, signup, loginWithToken, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/client/src/Contexts/authContext.ts
+++ b/client/src/Contexts/authContext.ts
@@ -1,0 +1,24 @@
+import { createContext } from "react";
+import type { LoginParams, SignupParams } from "../Services/authService";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  displayName: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+}
+
+export interface AuthContextValue {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+  login: (params: LoginParams) => Promise<void>;
+  signup: (params: SignupParams) => Promise<void>;
+  loginWithToken: (token: string, user: AuthUser) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/client/src/Contexts/useAuth.ts
+++ b/client/src/Contexts/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { AuthContext, AuthContextValue } from "./authContext";
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/client/src/Pages/DashboardPage/DashboardPage.test.tsx
+++ b/client/src/Pages/DashboardPage/DashboardPage.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "../../test/testHelpers";
+import DashboardPage from "./DashboardPage";
+
+describe("DashboardPage", () => {
+  it("renders dashboard heading", () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+});

--- a/client/src/Pages/DashboardPage/DashboardPage.tsx
+++ b/client/src/Pages/DashboardPage/DashboardPage.tsx
@@ -1,0 +1,27 @@
+import { useAuth } from "../../Contexts/useAuth";
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+
+  return (
+    <div className="dashboard-page">
+      <h2>Dashboard</h2>
+      {user && (
+        <div className="user-info">
+          <p>
+            <strong>Name:</strong> {user.firstName} {user.lastName}
+          </p>
+          <p>
+            <strong>Email:</strong> {user.email}
+          </p>
+          <p>
+            <strong>Display Name:</strong> {user.displayName}
+          </p>
+          <p>
+            <strong>Role:</strong> {user.role}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/Pages/LoginPage/LoginPage.test.tsx
+++ b/client/src/Pages/LoginPage/LoginPage.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "../../test/testHelpers";
+import LoginPage from "./LoginPage";
+
+describe("LoginPage", () => {
+  it("renders login form", () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Log In" })).toBeInTheDocument();
+  });
+
+  it("has a link to signup page", () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    expect(screen.getByRole("link", { name: "Sign up" })).toHaveAttribute(
+      "href",
+      "/signup",
+    );
+  });
+});

--- a/client/src/Pages/LoginPage/LoginPage.tsx
+++ b/client/src/Pages/LoginPage/LoginPage.tsx
@@ -1,0 +1,70 @@
+import { FormEvent, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../../Contexts/useAuth";
+
+export default function LoginPage() {
+  const { login, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const redirectTo = searchParams.get("redirectTo") || "/dashboard";
+
+  if (isAuthenticated) {
+    navigate(decodeURIComponent(redirectTo), { replace: true });
+    return null;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      await login({ email, password });
+      navigate(decodeURIComponent(redirectTo), { replace: true });
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response: { data: { error: string } } }).response?.data
+              ?.error
+          : "Login failed";
+      setError(message || "Login failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="auth-page">
+      <h2>Log In</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        {error && <p className="auth-error">{error}</p>}
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Logging in..." : "Log In"}
+        </button>
+      </form>
+      <p>
+        Don&apos;t have an account? <Link to="/signup">Sign up</Link>
+      </p>
+    </div>
+  );
+}

--- a/client/src/Pages/SignupPage/SignupPage.test.tsx
+++ b/client/src/Pages/SignupPage/SignupPage.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithProviders } from "../../test/testHelpers";
+import SignupPage from "./SignupPage";
+
+describe("SignupPage", () => {
+  it("renders signup form", () => {
+    renderWithProviders(<SignupPage />, { initialEntries: ["/signup"] });
+    expect(screen.getByLabelText("First Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Last Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign Up" })).toBeInTheDocument();
+  });
+
+  it("has a link to login page", () => {
+    renderWithProviders(<SignupPage />, { initialEntries: ["/signup"] });
+    expect(screen.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+  });
+});

--- a/client/src/Pages/SignupPage/SignupPage.tsx
+++ b/client/src/Pages/SignupPage/SignupPage.tsx
@@ -1,0 +1,86 @@
+import { FormEvent, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../../Contexts/useAuth";
+
+export default function SignupPage() {
+  const { signup, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  if (isAuthenticated) {
+    navigate("/dashboard", { replace: true });
+    return null;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      await signup({ email, password, firstName, lastName });
+      navigate("/dashboard", { replace: true });
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response: { data: { error: string } } }).response?.data
+              ?.error
+          : "Signup failed";
+      setError(message || "Signup failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="auth-page">
+      <h2>Sign Up</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        {error && <p className="auth-error">{error}</p>}
+        <label htmlFor="firstName">First Name</label>
+        <input
+          id="firstName"
+          type="text"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          required
+        />
+        <label htmlFor="lastName">Last Name</label>
+        <input
+          id="lastName"
+          type="text"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          required
+        />
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={8}
+        />
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Signing up..." : "Sign Up"}
+        </button>
+      </form>
+      <p>
+        Already have an account? <Link to="/login">Log in</Link>
+      </p>
+    </div>
+  );
+}

--- a/client/src/Routes/AppRoutes.tsx
+++ b/client/src/Routes/AppRoutes.tsx
@@ -1,0 +1,44 @@
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import App from "../App";
+import { AuthProvider } from "../Contexts/AuthProvider";
+import DashboardPage from "../Pages/DashboardPage/DashboardPage";
+import LoginPage from "../Pages/LoginPage/LoginPage";
+import SignupPage from "../Pages/SignupPage/SignupPage";
+import ProtectedRoute from "./ProtectedRoute";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: (
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    ),
+    children: [
+      {
+        index: true,
+        element: <LoginPage />,
+      },
+      {
+        path: "login",
+        element: <LoginPage />,
+      },
+      {
+        path: "signup",
+        element: <SignupPage />,
+      },
+      {
+        path: "dashboard",
+        element: (
+          <ProtectedRoute>
+            <DashboardPage />
+          </ProtectedRoute>
+        ),
+      },
+    ],
+  },
+]);
+
+export default function AppRoutes() {
+  return <RouterProvider router={router} />;
+}

--- a/client/src/Routes/ProtectedRoute.test.tsx
+++ b/client/src/Routes/ProtectedRoute.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { AuthProvider } from "../Contexts/AuthProvider";
+import ProtectedRoute from "./ProtectedRoute";
+
+describe("ProtectedRoute", () => {
+  it("redirects to login when not authenticated", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/login" element={<div>Login Page</div>} />
+            <Route
+              path="/dashboard"
+              element={
+                <ProtectedRoute>
+                  <div>Secret Content</div>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("Secret Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Login Page")).toBeInTheDocument();
+  });
+});

--- a/client/src/Routes/ProtectedRoute.tsx
+++ b/client/src/Routes/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../Contexts/useAuth";
+
+export default function ProtectedRoute({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    const redirectTo = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirectTo=${redirectTo}`} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/Services/apiClient.ts
+++ b/client/src/Services/apiClient.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_SERVER_BASE_URL,
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default apiClient;

--- a/client/src/Services/authService.ts
+++ b/client/src/Services/authService.ts
@@ -1,0 +1,46 @@
+import apiClient from "./apiClient";
+
+export interface AuthResponse {
+  user: {
+    id: string;
+    email: string;
+    displayName: string;
+    firstName: string;
+    lastName: string;
+    role: string;
+  };
+  token: string;
+}
+
+export interface SignupParams {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  displayName?: string;
+}
+
+export interface LoginParams {
+  email: string;
+  password: string;
+}
+
+export async function signup(params: SignupParams): Promise<AuthResponse> {
+  const response = await apiClient.post<AuthResponse>(
+    "/v1/auth/signup",
+    params,
+  );
+  return response.data;
+}
+
+export async function login(params: LoginParams): Promise<AuthResponse> {
+  const response = await apiClient.post<AuthResponse>("/v1/auth/login", params);
+  return response.data;
+}
+
+export async function googleAuth(credential: string): Promise<AuthResponse> {
+  const response = await apiClient.post<AuthResponse>("/v1/auth/google", {
+    credential,
+  });
+  return response.data;
+}

--- a/client/src/Services/userService.ts
+++ b/client/src/Services/userService.ts
@@ -1,0 +1,23 @@
+import apiClient from "./apiClient";
+
+export interface User {
+  id: string;
+  email: string;
+  displayName: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+}
+
+export async function getMe(): Promise<User> {
+  const response = await apiClient.get<User>("/v1/users/me");
+  return response.data;
+}
+
+export async function updateUser(
+  userId: string,
+  params: Partial<Pick<User, "displayName" | "firstName" | "lastName">>,
+): Promise<User> {
+  const response = await apiClient.put<User>(`/v1/users/${userId}`, params);
+  return response.data;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -24,15 +24,18 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
 h1 {
-  font-size: 3.2em;
+  font-size: 2em;
   line-height: 1.1;
+}
+
+h2 {
+  font-size: 1.5em;
+  line-height: 1.2;
 }
 
 button {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./App.tsx";
+import AppRoutes from "./Routes/AppRoutes";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <AppRoutes />
   </StrictMode>,
 );

--- a/client/src/test/testHelpers.tsx
+++ b/client/src/test/testHelpers.tsx
@@ -1,3 +1,8 @@
+import { render, RenderOptions } from "@testing-library/react";
+import { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { AuthProvider } from "../Contexts/AuthProvider";
+
 export class PromiseResolver<T = unknown> {
   reject!: (value: T) => void;
   resolve!: (value: T) => void;
@@ -9,4 +14,22 @@ export class PromiseResolver<T = unknown> {
       this.reject = reject;
     });
   }
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    initialEntries = ["/"],
+    ...options
+  }: RenderOptions & { initialEntries?: string[] } = {},
+) {
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={initialEntries}>
+        <AuthProvider>{children}</AuthProvider>
+      </MemoryRouter>
+    );
+  }
+
+  return render(ui, { wrapper: Wrapper, ...options });
 }


### PR DESCRIPTION
## Summary
- Set up React Router with public routes (`/login`, `/signup`) and protected routes (`/dashboard`)
- Auth state managed via React Context + localStorage (lightweight alternative to Redux)
- API service layer with axios (`apiClient`, `authService`, `userService`)
- Login and Signup page components with forms that call server auth endpoints
- ProtectedRoute wrapper that redirects to `/login` if not authenticated
- Dashboard page showing logged-in user info
- Navbar with auth-aware navigation (login/signup links vs. dashboard/logout)
- 10 tests passing across 6 test files

## Test plan
- [x] `make test-client` — all 10 tests pass
- [x] `make lint-client` — no warnings
- [x] `make build-client` — builds successfully
- [x] `make prettier-all` — all files formatted