### PR TITLE
Add scaffold DX improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,30 +90,30 @@ jobs:
       - run:
           name: Install required tools
           command: sudo apt-get update && sudo apt-get install -y jq
-      - run: 
+      - run:
           name: Fix permissions and prepare for Heroku
           command: |
             # Fix permissions from Docker
             sudo chown -R $USER:$USER ./server
-            
+
             # Create a deployment directory structure
             mkdir -p ./server/deploy/dist
-            
+
             # Copy compiled files and dependencies
             cp -r ./server/dist/* ./server/deploy/dist/
-            
+
             # Copy Sequelize configuration files
             cp ./server/.sequelizerc ./server/deploy/
-            
+
             # Copy package files but modify the build script
             cat ./server/package.json | jq '.scripts.build = "npm run migrate"' > ./server/deploy/package.json
             cp ./server/package-lock.json ./server/deploy/ || true
-            
+
             # Create Procfile that skips build entirely and properly runs migrations
             echo "release: npm run env:check && npx sequelize-cli --options-path=.sequelizerc db:migrate" > ./server/deploy/Procfile
             echo "web: node dist/server.js" >> ./server/deploy/Procfile
             echo "worker: node dist/worker.js" >> ./server/deploy/Procfile
-            
+
             # Create .slugignore
             echo "src/" > ./server/deploy/.slugignore
       - persist_to_workspace:
@@ -150,7 +150,7 @@ jobs:
             : "${DOCKERHUB_PASSWORD:?Set DOCKERHUB_PASSWORD in CircleCI project settings}"
             echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - run: docker compose run client npm run lint
-  
+
   test-client:
     machine: true
     working_directory: ~/src

--- a/.claude/skills/create-endpoint/SKILL.md
+++ b/.claude/skills/create-endpoint/SKILL.md
@@ -19,7 +19,10 @@ description: Step-by-step workflow for creating REST API endpoints with integrat
 
 ## Reference Implementation
 
-Study `server/src/api/healthCheck/` before creating a new endpoint. It shows the exact file structure, controller pattern, test pattern, and OpenAPI docs format used in this project.
+Study these before creating a new endpoint:
+
+- `server/src/api/auth/` — Full example with authentication, validation, and multiple routes (signup, login, Google OAuth)
+- `server/src/api/healthCheck/` — Minimal example showing the basic file structure and OpenAPI docs format
 
 ## Integration Testing
 
@@ -30,6 +33,7 @@ These are **integration tests** that test all functionality through the full sta
 ### Mocking Rules
 
 **Only mock at borders** — calls to outside services:
+
 - External APIs (Spotify, AWS S3, etc.)
 - Email services
 - Push notification services
@@ -44,7 +48,7 @@ Use `nock` for HTTP mocking (already set up in `mochaSetup.test.ts`).
 Always use `server/src/test/testDataGenerator.ts` for generating test models:
 
 ```typescript
-import { createUser } from "../../test/testDataGenerator";
+import { createUser } from '../../test/testDataGenerator';
 ```
 
 **DO NOT manually create users with hardcoded emails:**
@@ -52,18 +56,18 @@ import { createUser } from "../../test/testDataGenerator";
 ```typescript
 // BAD - can cause duplicate email conflicts between tests
 const adminUser = await db.models.User.create({
-  email: "admin@example.com",
-  role: "admin",
+  email: 'admin@example.com',
+  role: 'admin',
 });
 
 // GOOD - let testDataGenerator handle unique emails
-const adminUser = await createUser(db, { role: "admin" });
+const adminUser = await createUser(db, { role: 'admin' });
 ```
 
 ### Generating Tokens
 
 ```typescript
-import { generateToken } from "../../utils/jwt";
+import { generateToken } from '../../utils/jwt';
 
 const user = await createUser(db);
 const token = await generateToken(user);
@@ -78,28 +82,28 @@ If `generateToken` doesn't exist yet, create a JWT token directly using the user
 ### Test Pattern
 
 ```typescript
-import { assert } from "chai";
-import request from "supertest";
-import app from "../../server";
-import db from "../../db";
-import { createUser } from "../../test/testDataGenerator";
+import { assert } from 'chai';
+import request from 'supertest';
+import app from '../../server';
+import db from '../../db';
+import { createUser } from '../../test/testDataGenerator';
 
-describe("[Module] API", function () {
-  describe("GET /v1/[module]", function () {
-    it("returns the resource", async function () {
-      const user = await createUser(db, { role: "admin" });
+describe('[Module] API', function () {
+  describe('GET /v1/[module]', function () {
+    it('returns the resource', async function () {
+      const user = await createUser(db, { role: 'admin' });
       // generate token for auth...
 
       const res = await request(app)
-        .get("/v1/[module]")
-        .set("Authorization", `Bearer ${token}`)
+        .get('/v1/[module]')
+        .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
       assert.exists(res.body.id);
     });
 
-    it("returns 401 without auth", async function () {
-      await request(app).get("/v1/[module]").expect(401);
+    it('returns 401 without auth', async function () {
+      await request(app).get('/v1/[module]').expect(401);
     });
   });
 });
@@ -126,20 +130,20 @@ GET  /v1/users/:userId      → Get specific user (admin)
 
 ### HTTP Methods & Status Codes
 
-| Method | Purpose | Success Code |
-|--------|---------|-------------|
-| GET | Retrieve resource(s) | 200 |
-| POST | Create resource | 201 |
-| PUT | Update resource | 200 |
-| DELETE | Remove resource | 200 |
+| Method | Purpose              | Success Code |
+| ------ | -------------------- | ------------ |
+| GET    | Retrieve resource(s) | 200          |
+| POST   | Create resource      | 201          |
+| PUT    | Update resource      | 200          |
+| DELETE | Remove resource      | 200          |
 
-| Error Code | Usage |
-|------------|-------|
-| 400 | Validation error, bad request |
-| 401 | Authentication failure |
-| 403 | Permission/authorization failure |
-| 404 | Resource not found |
-| 409 | Conflict error |
+| Error Code | Usage                            |
+| ---------- | -------------------------------- |
+| 400        | Validation error, bad request    |
+| 401        | Authentication failure           |
+| 403        | Permission/authorization failure |
+| 404        | Resource not found               |
+| 409        | Conflict error                   |
 
 ### Authentication & Authorization Middleware Stack
 
@@ -147,19 +151,19 @@ Apply middleware in this order on protected routes:
 
 ```typescript
 router.get(
-  "/:id",
-  authenticate,                           // 1. Validate JWT
-  validateUUIDsInParams(["id"]),          // 2. Validate UUID format
-  requireRoleOfAtLeast("user"),           // 3. Check permissions
-  controller.get,                          // 4. Handler
+  '/:id',
+  authenticate, // 1. Validate JWT
+  validateUUIDsInParams(['id']), // 2. Validate UUID format
+  requireRoleOfAtLeast('user'), // 3. Check permissions
+  controller.get, // 4. Handler
 );
 
 router.post(
-  "/",
+  '/',
   authenticate,
-  checkBodyFor(["name", "email"]),         // Required fields
-  checkBodyForNoExtraFields(["name", "email", "role"]),  // No extra fields
-  validateUUIDsInBody(["relatedId"]),     // UUID format in body
+  checkBodyFor(['name', 'email']), // Required fields
+  checkBodyForNoExtraFields(['name', 'email', 'role']), // No extra fields
+  validateUUIDsInBody(['relatedId']), // UUID format in body
   controller.create,
 );
 ```
@@ -167,17 +171,19 @@ router.post(
 **Permission Middleware Options:**
 
 ```typescript
-requireRoleOfAtLeast("admin")         // Roles: guest < user < admin
-isOperatingOnSelf("userId")           // User can only operate on own data
-oneOf([                               // OR logic
-  isOperatingOnSelf("userId"),
-  requireRoleOfAtLeast("admin"),
-])
+requireRoleOfAtLeast('admin'); // Roles: guest < user < admin
+isOperatingOnSelf('userId'); // User can only operate on own data
+oneOf([
+  // OR logic
+  isOperatingOnSelf('userId'),
+  requireRoleOfAtLeast('admin'),
+]);
 ```
 
 ### Error Handling
 
 **Error Classes (in `utils/errors.ts`):**
+
 - `NotFoundError` → 404
 - `AuthenticationError` → 401
 - `PermissionError` → 403
@@ -187,10 +193,11 @@ oneOf([                               // OR logic
 ```typescript
 // Use centralized error messages
 throw new NotFoundError(ErrorMessages.RESOURCE_NOT_FOUND);
-throw new ValidationError(ErrorMessages.invalidUuidFormat("userId"));
+throw new ValidationError(ErrorMessages.invalidUuidFormat('userId'));
 ```
 
 **Controller pattern:**
+
 ```typescript
 async function handler(req: Request, res: Response, next: NextFunction) {
   try {
@@ -244,11 +251,11 @@ make build-server
 In `server/src/api/routes.ts`, add the new route:
 
 ```typescript
-import moduleApi from "./[module]";
+import moduleApi from './[module]';
 
 function addRoutes(app: Application) {
   // ... existing routes
-  app.use("/v1/[module]", moduleApi);
+  app.use('/v1/[module]', moduleApi);
 }
 ```
 

--- a/.claude/skills/create-feature/SKILL.md
+++ b/.claude/skills/create-feature/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: create-feature
+description: Step-by-step workflow for creating a client feature with service, context, page, and route
+---
+
+# Client Feature Development
+
+## Development Workflow
+
+1. Create the API service (`client/src/Services/[feature]Service.ts`)
+2. Create the context if needed (`client/src/Contexts/[Feature]Provider.tsx`, `[feature]Context.ts`, `use[Feature].ts`)
+3. Create the page component (`client/src/Pages/[Feature]Page/[Feature]Page.tsx`)
+4. Write tests for the page (`client/src/Pages/[Feature]Page/[Feature]Page.test.tsx`)
+5. Add the route to `client/src/Routes/AppRoutes.tsx`
+6. Verify: `make test-client && make lint-client`
+
+## Reference Implementations
+
+Study these existing files before creating a new feature:
+
+- **Service**: `client/src/Services/authService.ts` — typed API calls using `apiClient`
+- **Context**: `client/src/Contexts/AuthProvider.tsx` + `authContext.ts` + `useAuth.ts` — full context pattern
+- **Page**: `client/src/Pages/LoginPage/LoginPage.tsx` — form handling, error state, navigation
+- **Route**: `client/src/Routes/AppRoutes.tsx` — route registration with protected routes
+- **Test**: `client/src/Pages/LoginPage/LoginPage.test.tsx` — component testing with React Testing Library
+
+## File Organization
+
+```
+client/src/
+├── Services/
+│   └── [feature]Service.ts        # API calls (typed request/response)
+├── Contexts/
+│   ├── [Feature]Provider.tsx      # Provider component with state logic
+│   ├── [feature]Context.ts        # Context + types (no logic)
+│   └── use[Feature].ts            # Custom hook (useContext wrapper)
+├── Pages/
+│   └── [Feature]Page/
+│       ├── [Feature]Page.tsx       # Page component
+│       └── [Feature]Page.test.tsx  # Tests
+└── Routes/
+    └── AppRoutes.tsx              # Add route here
+```
+
+## Service Pattern
+
+```typescript
+import apiClient from './apiClient';
+
+export interface Feature {
+  id: string;
+  name: string;
+}
+
+export async function getFeatures(): Promise<Feature[]> {
+  const response = await apiClient.get<Feature[]>('/v1/features');
+  return response.data;
+}
+
+export async function createFeature(params: { name: string }): Promise<Feature> {
+  const response = await apiClient.post<Feature>('/v1/features', params);
+  return response.data;
+}
+```
+
+The `apiClient` (in `Services/apiClient.ts`) automatically attaches the JWT token from localStorage via an interceptor.
+
+## Context Pattern
+
+Only create a context when state needs to be shared across multiple components. For simple pages that fetch data once, use local state instead.
+
+### Context file (`[feature]Context.ts`)
+
+```typescript
+import { createContext } from 'react';
+
+export interface FeatureContextValue {
+  items: Feature[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export const FeatureContext = createContext<FeatureContextValue | null>(null);
+```
+
+### Hook file (`use[Feature].ts`)
+
+```typescript
+import { useContext } from 'react';
+import { FeatureContext, FeatureContextValue } from './[feature]Context';
+
+export function useFeature(): FeatureContextValue {
+  const context = useContext(FeatureContext);
+  if (!context) {
+    throw new Error('useFeature must be used within a FeatureProvider');
+  }
+  return context;
+}
+```
+
+### Provider file (`[Feature]Provider.tsx`)
+
+```typescript
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import * as featureService from "../Services/[feature]Service";
+import { FeatureContext } from "./[feature]Context";
+
+export function FeatureProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const data = await featureService.getFeatures();
+    setItems(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const value = useMemo(() => ({ items, loading, refresh }), [items, loading, refresh]);
+
+  return <FeatureContext.Provider value={value}>{children}</FeatureContext.Provider>;
+}
+```
+
+## Page Pattern
+
+```typescript
+import { useAuth } from "../../Contexts/useAuth";
+
+export default function FeaturePage() {
+  // Local state for simple data fetching, or useFeature() for shared context
+  return (
+    <div>
+      <h2>Feature</h2>
+      {/* ... */}
+    </div>
+  );
+}
+```
+
+## Testing Pattern
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders } from "../../test/testHelpers";
+import FeaturePage from "./FeaturePage";
+
+describe("FeaturePage", () => {
+  it("renders the page heading", () => {
+    renderWithProviders(<FeaturePage />);
+    expect(screen.getByRole("heading", { name: /feature/i })).toBeInTheDocument();
+  });
+});
+```
+
+Use `renderWithProviders` from `test/testHelpers.tsx` when the component needs AuthContext or Router context.
+
+## Route Registration
+
+In `client/src/Routes/AppRoutes.tsx`:
+
+```typescript
+import FeaturePage from "../Pages/FeaturePage/FeaturePage";
+
+// Add to the children array in the router:
+{
+  path: "feature",
+  element: (
+    <ProtectedRoute>
+      <FeaturePage />
+    </ProtectedRoute>
+  ),
+},
+```
+
+Use `<ProtectedRoute>` for authenticated pages. Public pages don't need it.
+
+## Quality Gates
+
+- [ ] Service functions are typed (request params and response)
+- [ ] Page renders without errors
+- [ ] Tests written and passing
+- [ ] Route registered in AppRoutes.tsx
+- [ ] `make test-client` passes
+- [ ] `make lint-client` passes
+- [ ] `make prettier-client` passes

--- a/.claude/skills/create-lib/SKILL.md
+++ b/.claude/skills/create-lib/SKILL.md
@@ -21,7 +21,10 @@ Never implement multiple functions in parallel. Complete the full cycle for one 
 
 ## Reference Implementation
 
-Study `server/src/lib/healthCheck/healthCheck.lib.ts` for the existing pattern.
+Study these for the existing patterns:
+
+- `server/src/lib/auth/auth.lib.ts` — Full example with user creation, password hashing, token generation
+- `server/src/lib/healthCheck/healthCheck.lib.ts` — Minimal example
 
 ## File Organization
 
@@ -47,23 +50,23 @@ server/src/lib/[module]/
 ### Test Pattern
 
 ```typescript
-import { assert } from "chai";
-import db from "../../db";
-import { createUser } from "../../test/testDataGenerator";
-import * as moduleLib from "./[module].lib";
+import { assert } from 'chai';
+import db from '../../db';
+import { createUser } from '../../test/testDataGenerator';
+import * as moduleLib from './[module].lib';
 
-describe("[module] lib", function () {
-  describe("functionName", function () {
-    it("does the expected thing", async function () {
+describe('[module] lib', function () {
+  describe('functionName', function () {
+    it('does the expected thing', async function () {
       const user = await createUser(db);
       const result = await moduleLib.functionName(user.id);
       assert.exists(result);
     });
 
-    it("throws NotFoundError for non-existent resource", async function () {
+    it('throws NotFoundError for non-existent resource', async function () {
       try {
-        await moduleLib.functionName("non-existent-id");
-        assert.fail("should have thrown");
+        await moduleLib.functionName('non-existent-id');
+        assert.fail('should have thrown');
       } catch (err) {
         assert.instanceOf(err, NotFoundError);
       }
@@ -77,17 +80,17 @@ describe("[module] lib", function () {
 Always use `server/src/test/testDataGenerator.ts`:
 
 ```typescript
-import { createUser } from "../../test/testDataGenerator";
+import { createUser } from '../../test/testDataGenerator';
 ```
 
 **DO NOT manually create users with hardcoded emails:**
 
 ```typescript
 // BAD - can cause duplicate email conflicts between tests
-const user = await db.models.User.create({ email: "test@example.com" });
+const user = await db.models.User.create({ email: 'test@example.com' });
 
 // GOOD - let testDataGenerator handle unique emails
-const user = await createUser(db, { role: "admin" });
+const user = await createUser(db, { role: 'admin' });
 ```
 
 ## Test Commands

--- a/.claude/skills/create-model/SKILL.md
+++ b/.claude/skills/create-model/SKILL.md
@@ -41,11 +41,11 @@ Location: `server/src/db/migrations/[timestamp]-[description].js`
 Timestamp format: `YYYYMMDDHHMMSS` (e.g., `20260301000001`)
 
 ```javascript
-"use strict";
+'use strict';
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable("tableName", {
+    await queryInterface.createTable('tableName', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -56,24 +56,24 @@ module.exports = {
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
       updatedAt: {
         allowNull: false,
         type: Sequelize.DATE,
-        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 
     // Add indexes as needed
-    await queryInterface.addIndex("tableName", {
-      fields: ["fieldName"],
-      name: "table_name_field_name",
+    await queryInterface.addIndex('tableName', {
+      fields: ['fieldName'],
+      name: 'table_name_field_name',
     });
   },
 
   async down(queryInterface) {
-    await queryInterface.dropTable("tableName");
+    await queryInterface.dropTable('tableName');
   },
 };
 ```
@@ -91,13 +91,10 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
-} from "sequelize";
-import sequelize from "../../sequelize";
+} from 'sequelize';
+import sequelize from '../../sequelize';
 
-class ModelName extends Model<
-  InferAttributes<ModelName>,
-  InferCreationAttributes<ModelName>
-> {
+class ModelName extends Model<InferAttributes<ModelName>, InferCreationAttributes<ModelName>> {
   // Required fields
   declare fieldName: string;
 
@@ -130,7 +127,7 @@ ModelName.init(
   },
   {
     sequelize,
-    modelName: "modelName", // camelCase
+    modelName: 'modelName', // camelCase
   },
 );
 
@@ -142,8 +139,8 @@ export default ModelName;
 Location: `server/src/db/models/[modelName].model/index.ts`
 
 ```typescript
-export { default } from "./modelName.model";
-export { default as ModelName } from "./modelName.model";
+export { default } from './modelName.model';
+export { default as ModelName } from './modelName.model';
 ```
 
 ### 4. Register the Model
@@ -156,12 +153,12 @@ Add associations directly in the model file or create `server/src/db/association
 
 ```typescript
 ModelName.belongsTo(RelatedModel, {
-  foreignKey: "relatedModelId",
-  as: "relatedModel",
+  foreignKey: 'relatedModelId',
+  as: 'relatedModel',
 });
 
 RelatedModel.hasMany(ModelName, {
-  foreignKey: "relatedModelId",
+  foreignKey: 'relatedModelId',
 });
 ```
 
@@ -171,7 +168,7 @@ Add a factory function in `server/src/test/testDataGenerator.ts`:
 
 ```typescript
 export async function createModelName(
-  db: typeof import("../db"),
+  db: typeof import('../db'),
   overrides: Partial<ModelNameAttributes> = {},
 ) {
   return db.models.ModelName.create({
@@ -184,6 +181,7 @@ export async function createModelName(
 ## Model Testing
 
 **Only test complex models** that have:
+
 - Virtual properties
 - Custom instance methods
 - Hooks (beforeCreate, afterUpdate, etc.)
@@ -194,13 +192,13 @@ Simple models with just data fields don't need tests.
 ### Test Pattern
 
 ```typescript
-import { assert } from "chai";
-import db from "../..";
-import { createModelName } from "../../../test/testDataGenerator";
+import { assert } from 'chai';
+import db from '../..';
+import { createModelName } from '../../../test/testDataGenerator';
 
-describe("ModelName Model", function () {
-  describe("customMethod", function () {
-    it("returns expected value", async function () {
+describe('ModelName Model', function () {
+  describe('customMethod', function () {
+    it('returns expected value', async function () {
       const instance = await createModelName(db);
       assert.isTrue(instance.customMethod());
     });
@@ -246,6 +244,7 @@ relatedModelId: {
 ### Uppercase Constraint (for codes)
 
 In migration:
+
 ```javascript
 await queryInterface.sequelize.query(`
   ALTER TABLE "tableName"

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -2,7 +2,7 @@
 name: deploy
 description: Interactive deployment setup guide for Render, Cloudflare, CircleCI, and Google OAuth
 disable-model-invocation: true
-argument-hint: "[all|render|cloudflare|circleci|google-oauth|env|status]"
+argument-hint: '[all|render|cloudflare|circleci|google-oauth|env|status]'
 ---
 
 # Deployment Setup Guide
@@ -12,6 +12,7 @@ You are an interactive deployment assistant. Walk the user through deploying thi
 ## Current Project State
 
 Before starting, read these files to understand what's already configured:
+
 - `server/.env` — current environment variables
 - `server/.env-example` — available env vars
 - `.env` — root env (PORT_OFFSET, ports)

--- a/.claude/skills/diagnose-flaky/SKILL.md
+++ b/.claude/skills/diagnose-flaky/SKILL.md
@@ -22,7 +22,7 @@ Add conditional logging that only prints on failure:
 
 ```typescript
 if (actualValue !== expectedValue) {
-  console.log("DEBUG flaky test - failure state:", {
+  console.log('DEBUG flaky test - failure state:', {
     actualValue,
     expectedValue,
     relevantState: someVariable,
@@ -47,26 +47,31 @@ The script stops on first failure and shows the debug output.
 ### 3. Common Causes of Flaky Tests
 
 #### Timezone Issues
+
 Tests that check dates/times may fail when local time crosses a day boundary in UTC.
 
 **Fix:** Use timezone-aware assertions or freeze to a specific time that avoids boundary issues.
 
 #### Random Selection
+
 Tests involving random choices may not always hit the expected branch.
 
 **Fix:** Seed the random number generator or assert over a range of valid outcomes.
 
 #### Database State
+
 Tests may pollute shared database state or run in unexpected order.
 
 **Fix:** Ensure proper cleanup. The `clearDatabase()` function in `test.helpers.ts` runs in `afterEach` via `mochaSetup.test.ts`. If a test needs specific isolation, add explicit setup/teardown.
 
 #### Race Conditions
+
 Async operations completing in different orders.
 
 **Fix:** Use proper `await` and ensure deterministic ordering.
 
 #### nock Leaks
+
 HTTP mocks from one test leaking into the next.
 
 **Fix:** Call `nock.cleanAll()` in `afterEach` for tests that set up nocks. The global `mochaSetup.test.ts` already handles this, but test-specific nocks may need explicit cleanup.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: "Version increment type"
+        description: 'Version increment type'
         required: true
-        default: "patch"
+        default: 'patch'
         type: choice
         options:
           - patch
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Get current version
         id: current_version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 ## Project Structure
 
 Monorepo with two components:
+
 - **Server**: Node.js 22.15.0 backend, TypeScript, Express 5, Sequelize ORM, PostgreSQL
 - **Client**: React frontend with Vite
 
@@ -8,17 +9,18 @@ Docker Compose for orchestration. All cross-project commands are in the root `Ma
 
 ## Task-Type Quick Reference
 
-| Task Type | Read This |
-|-----------|-----------|
-| Creating a database model | `/create-model` skill |
-| Creating library functions | `/create-lib` skill |
-| Creating an API endpoint | `/create-endpoint` skill |
-| Debugging flaky tests | `/diagnose-flaky` skill |
-| React component work | Client Architecture section below |
+| Task Type                  | Read This                |
+| -------------------------- | ------------------------ |
+| Creating a database model  | `/create-model` skill    |
+| Creating library functions | `/create-lib` skill      |
+| Creating an API endpoint   | `/create-endpoint` skill |
+| Creating a client feature  | `/create-feature` skill  |
+| Debugging flaky tests      | `/diagnose-flaky` skill  |
 
 ## Codebase Map
 
 ### Server (`/server/src/`)
+
 - `api/` — REST endpoints (one dir per module: `index.ts`, `[module].api.ts`, `[module].api.test.ts`, `[module].api.docs.yaml`)
 - `api/routes.ts` — Central route mounting
 - `api/security.ts` — Auth middleware (JWT, Basic Auth, role checks)
@@ -32,14 +34,22 @@ Docker Compose for orchestration. All cross-project commands are in the root `Ma
 - `middleware/errorHandler.ts` — Express error handler
 
 ### Client (`/client/src/`)
-- `Components/` — React components
-- `App.tsx` — Root component
+
+- `Components/` — Reusable React components (Navbar, etc.)
+- `Contexts/` — React context providers (`AuthProvider`, `authContext`, `useAuth` hook)
+- `Pages/` — Page components (one dir per page: `LoginPage/`, `SignupPage/`, `DashboardPage/`)
+- `Routes/` — Router config (`AppRoutes.tsx`, `ProtectedRoute.tsx`)
+- `Services/` — API client layer (`apiClient.ts`, `authService.ts`, `userService.ts`)
+- `test/` — Test setup and helpers
+- `App.tsx` — Root component (layout shell with `<Outlet />`)
+- `main.tsx` — Entry point
 
 ## Development Commands
 
 All commands run via `make` from the project root. These execute inside Docker containers.
 
 ### Essential Commands
+
 - `make prettier-all` — **Run before every push** to format all files
 - `make test-server` — Run server tests
 - `make lint-server` — Run server linter
@@ -51,11 +61,13 @@ All commands run via `make` from the project root. These execute inside Docker c
 - `make prettier-client` — Format client files only
 
 ### Database Commands
+
 - `make migrate` — Run pending migrations
 - `make migrate-all` — Run migrations for dev and test DBs
 - `make generate-migration NAME=migration-name` — Create a new migration
 
 ### Docker Commands
+
 - `make install` — Initial setup (copy env files, set ports, build containers)
 - `make launch` — Start all services
 - `make launch-detached` — Start all services in background
@@ -66,6 +78,7 @@ All commands run via `make` from the project root. These execute inside Docker c
 ## Before Pushing
 
 Always run:
+
 ```
 make prettier-all
 ```
@@ -73,6 +86,7 @@ make prettier-all
 ## Code Style Guide
 
 ### TypeScript Best Practices
+
 - **All new files must be TypeScript** — no new `.js` files
 - Use type inference where context makes types obvious
 - Explicitly annotate function parameters and return types
@@ -84,21 +98,23 @@ make prettier-all
 Define enum constants in the model file as the single source of truth:
 
 ```typescript
-export const USER_ROLES = ["admin", "user", "guest"] as const;
+export const USER_ROLES = ['admin', 'user', 'guest'] as const;
 export type UserRole = (typeof USER_ROLES)[number];
 ```
 
 Use in routes for validation:
-```typescript
-import { USER_ROLES } from "../../db/models/user.model";
-import { checkBodyEnum } from "../validation";
 
-router.put("/:id/role", checkBodyEnum("role", USER_ROLES), controller.updateRole);
+```typescript
+import { USER_ROLES } from '../../db/models/user.model';
+import { checkBodyEnum } from '../validation';
+
+router.put('/:id/role', checkBodyEnum('role', USER_ROLES), controller.updateRole);
 ```
 
 ## Testing Strategy
 
 ### Server Testing
+
 - Mocha + Chai for test framework with co-located `.test.ts` files
 - Integration tests for API endpoints using Supertest
 - HTTP mocking with Nock for external API calls
@@ -107,12 +123,14 @@ router.put("/:id/role", checkBodyEnum("role", USER_ROLES), controller.updateRole
 - Tests clear the database between runs (`afterEach`)
 
 ### Client Testing
+
 - Vitest with jsdom environment
 - React Testing Library for component behavior testing
 
 ## Building New Endpoints (TDD)
 
 Follow this exact procedure:
+
 1. Write library tests in `/server/src/lib/[module]/[module].lib.test.ts`
 2. See them fail (red)
 3. Write library functions in `/server/src/lib/[module]/[module].lib.ts`
@@ -129,6 +147,7 @@ Follow this exact procedure:
 **Important**: Implement one function at a time. Write tests for one function, implement it, verify, then move to the next.
 
 ## API Design
+
 - RESTful endpoints with `/v1/` versioning
 - Resource-based organization — no "summary" endpoints combining unrelated data
 - JWT authentication via `authenticate` middleware in `security.ts`
@@ -136,12 +155,14 @@ Follow this exact procedure:
 - Error handling via custom error classes thrown from lib layer
 
 ## Documentation Standards
+
 - OpenAPI/Swagger YAML in `.api.docs.yaml` files
 - Never use relative paths between YAML files
 - Reference components as if all definitions are in a single file
 - Use `$ref: '#/components/responses/400'` for common error responses
 
 ## Docker & Multi-Instance Support
+
 - `COMPOSE_PROJECT_NAME` in root `.env` handles container naming — never use hardcoded `container_name` in `docker-compose.yaml`
 - Port variables (`POSTGRES_PORT`, `SERVER_PORT`, etc.) in root `.env` enable multiple instances
 
@@ -150,6 +171,7 @@ Follow this exact procedure:
 When the user's request matches an available skill, invoke it using the Skill tool as your FIRST action.
 
 Key routing rules:
+
 - Bugs, errors, "why is this broken" → invoke investigate
 - Ship, deploy, push, create PR → invoke ship
 - QA, test the site, find bugs → invoke qa

--- a/README.md
+++ b/README.md
@@ -1,216 +1,222 @@
 # Node/React Scaffold
 
-A modern full-stack TypeScript application template with React frontend and Node.js backend. Includes Docker containerization, automated testing, CI/CD integration, and Claude Code skills for AI-assisted development.
+A production-ready full-stack TypeScript starter with authentication, protected routes, and AI-assisted development built in.
 
-## Tech Stack
+## What's Included
 
-### Backend (Node.js)
-- Express.js web framework
-- PostgreSQL with Sequelize ORM
-- TypeScript
-- JWT authentication with role-based access control
-- BullMQ job queues with Redis (optional)
-- Background worker with cron scheduling
-- OpenAPI 3.0 documentation (Swagger/ReDoc)
+### Authentication (ready to use)
 
-### Frontend (React)
-- Vite for fast development and building
-- React 18 with TypeScript
-- Vitest and React Testing Library
-- ESLint + Prettier
+- **Server**: `POST /v1/auth/signup`, `/login`, `/google` endpoints returning `{ user, token }`
+- **Client**: Login/signup pages, protected routes, AuthContext, JWT token management
+- **Security**: Password hashing (bcrypt), JWT authentication, role-based access control
+
+### Server
+
+- Express 5 with TypeScript
+- PostgreSQL with Sequelize ORM and migrations
+- OpenAPI 3.0 documentation (ReDoc + Swagger)
+- BullMQ background worker with cron scheduling (optional Redis)
+- Mocha + Chai + Supertest integration tests
+
+### Client
+
+- React 18 with Vite and TypeScript
+- React Router with protected routes
+- Axios API service layer with JWT interceptor
+- Vitest + React Testing Library
 
 ### Infrastructure
+
 - Docker Compose for local development
-- CircleCI for CI/CD
-- GitHub Actions for release PR automation
+- Automatic port management (multiple instances supported)
+- CircleCI CI/CD pipeline
+- GitHub Actions release PR automation
+- Claude Code skills for AI-assisted development
+
+## Quick Start
+
+```bash
+git clone <repository-url>
+cd node-react-scaffold
+
+# Optional: rename the project
+./scripts/init-project.sh
+
+# Install and launch
+make install
+make launch
+```
+
+`make install` copies env files, finds open ports, and builds Docker images.
+
+Once running:
+
+- Frontend: http://localhost:3000
+- Backend API: http://localhost:10020
+- API docs: http://localhost:10020/docs
+
+## Optional Features
+
+### Redis & BullMQ Job Queues
+
+Background job processing is included but Redis is disabled by default.
+
+1. Uncomment the `redis` service in `docker-compose.yaml`
+2. Uncomment `REDIS_URL=redis://redis:6379` in `server/.env`
+3. `make restart`
+
+### Google OAuth
+
+The `/v1/auth/google` endpoint is wired up. To enable it:
+
+1. Create OAuth credentials in [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
+2. Add `GOOGLE_CLIENT_ID` to `server/.env`
+3. Add the Google sign-in button to your login page
+
+### Metrics & Monitoring
+
+The worker service supports cron-based jobs out of the box. Add monitoring by:
+
+1. Adding a health check endpoint for your monitoring service
+2. Configuring alerts on the `/v1/health-check` endpoint
 
 ## Prerequisites
 
 - Docker and Docker Compose
 - Node.js 22.15.0 and npm 10.9.2 (matches Docker images; consider using nvm)
 
-## Getting Started
+## Port Management
 
-```bash
-git clone <repository-url>
-cd scaffold
-make install
-make launch
-```
+The project uses `PORT_OFFSET` (in `.env`) to avoid port conflicts when running multiple instances. Each instance offsets all ports by this value (in increments of 100). Run `make find-open-ports` to auto-detect an available offset.
 
-`make install` handles everything: copies `.env-example` files, finds open ports, and builds Docker images.
+| Service      | Base Port | With PORT_OFFSET=100 |
+| ------------ | --------- | -------------------- |
+| Client       | 3000      | 3100                 |
+| Client HMR   | 3010      | 3110                 |
+| Server       | 10020     | 10120                |
+| Server Debug | 9229      | 9329                 |
+| PostgreSQL   | 5432      | 5532                 |
+| Worker       | 10030     | 10130                |
 
-This starts:
-- Frontend at http://localhost:3000
-- Backend API at http://localhost:10020
-- API docs at http://localhost:10020/docs
-- Background worker
-- PostgreSQL database
-- Automatic database migrations
+## Environment Files
 
-### Port Management
-
-The project uses `PORT_OFFSET` (in `.env`) to avoid port conflicts when running multiple scaffold instances. Each instance offsets all ports by this value (in increments of 100). Run `make find-open-ports` to auto-detect an available offset.
-
-| Service | Base Port | With PORT_OFFSET=100 |
-|---------|-----------|---------------------|
-| Client | 3000 | 3100 |
-| Client HMR | 3010 | 3110 |
-| Server | 10020 | 10120 |
-| Server Debug | 9229 | 9329 |
-| PostgreSQL | 5432 | 5532 |
-| Worker | 10030 | 10130 |
-
-### Environment Files
-
-| File | Purpose |
-|------|---------|
-| `.env` | Root config (PORT_OFFSET) |
-| `server/.env` | Server runtime config |
-| `server/.env-test` | Test database config (auto-created) |
-| `client/.env` | Client config (optional) |
-
-### Customizing for Your Project
-
-1. Update `container_name` entries in `docker-compose.yaml` (replace `YOUR_PROJECT_NAME`)
-2. Update `server/src/config/config.ts` production values (`BASE_URL`, `CLIENT_BASE_URL`)
-3. Update `server/src/docs/index.ts` with your API title and contact info
-
-### Optional: Redis
-
-To enable Redis for job queues:
-
-1. Uncomment the `redis` service in `docker-compose.yaml`
-2. Uncomment `REDIS_URL=redis://redis:6379` in `server/.env`
-3. Restart: `make restart`
-
-### Optional: Pre-commit Hook
-
-```bash
-./hooks/setup.sh
-```
-
-Runs Prettier inside Docker containers before each commit. Requires `make launch` to be running.
+| File               | Purpose                                          |
+| ------------------ | ------------------------------------------------ |
+| `.env`             | Root config (COMPOSE_PROJECT_NAME, PORT_OFFSET)  |
+| `server/.env`      | Server runtime config (JWT_SECRET, DATABASE_URL) |
+| `server/.env-test` | Test database config (auto-created)              |
+| `client/.env`      | Client config (API base URL)                     |
 
 ## Claude Code Skills
 
-This project includes [Claude Code](https://claude.ai/claude-code) skills for AI-assisted development. After installing Claude Code, these slash commands are available:
+This project includes [Claude Code](https://claude.ai/claude-code) skills for AI-assisted development:
 
-| Command | Description |
-|---------|-------------|
-| `/create-model` | Create a Sequelize model with migration, types, and tests (TDD) |
-| `/create-endpoint` | Create a REST API endpoint with integration tests and OpenAPI docs |
-| `/create-lib` | Create library functions with TDD, one function at a time |
-| `/diagnose-flaky` | Step-by-step flaky test diagnosis |
-| `/deploy` | Interactive deployment setup (Render, Cloudflare, CircleCI, Google OAuth) |
+| Command            | Description                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| `/create-model`    | Create a Sequelize model with migration, types, and tests (TDD)           |
+| `/create-endpoint` | Create a REST API endpoint with integration tests and OpenAPI docs        |
+| `/create-lib`      | Create library functions with TDD, one function at a time                 |
+| `/create-feature`  | Create a client feature (service + context + page + route)                |
+| `/diagnose-flaky`  | Step-by-step flaky test diagnosis                                         |
+| `/deploy`          | Interactive deployment setup (Render, Cloudflare, CircleCI, Google OAuth) |
 
 Skills live in `.claude/skills/` and teach Claude the project's conventions so it generates code that matches existing patterns.
 
 ## Make Targets
 
 ### Core
-| Target | Description |
-|--------|-------------|
-| `make install` | Set up env files, find ports, build Docker images |
-| `make launch` | Start all services (foreground) |
-| `make launch-detached` | Start all services (background) |
-| `make terminate` | Stop all services |
-| `make restart` | Stop and restart all services |
+
+| Target                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `make install`         | Set up env files, find ports, build Docker images |
+| `make launch`          | Start all services (foreground)                   |
+| `make launch-detached` | Start all services (background)                   |
+| `make terminate`       | Stop all services                                 |
+| `make restart`         | Stop and restart all services                     |
 
 ### Testing
-| Target | Description |
-|--------|-------------|
-| `make test-server` | Run all server tests |
+
+| Target                                 | Description                       |
+| -------------------------------------- | --------------------------------- |
+| `make test-server`                     | Run all server tests              |
 | `make test-server-file GREP="pattern"` | Run tests matching a grep pattern |
-| `make test-server-with-logging` | Run tests with verbose logging |
-| `make test-server-debug` | Run tests with Node debugger attached |
-| `make test-client` | Run client tests |
+| `make test-client`                     | Run client tests                  |
 
 ### Code Quality
-| Target | Description |
-|--------|-------------|
-| `make lint-server` | Lint server (ESLint + Prettier check) |
-| `make lint-client` | Lint client |
-| `make prettier-server` | Auto-format server files |
-| `make prettier-client` | Auto-format client files |
-| `make prettier-all` | Auto-format everything |
+
+| Target              | Description                           |
+| ------------------- | ------------------------------------- |
+| `make lint-server`  | Lint server (ESLint + Prettier check) |
+| `make lint-client`  | Lint client                           |
+| `make prettier-all` | Auto-format everything                |
 
 ### Build & Database
-| Target | Description |
-|--------|-------------|
-| `make build-server` | Compile TypeScript |
-| `make build-client` | Build production client bundle |
-| `make migrate` | Run database migrations |
-| `make migrate-all` | Run migrations for dev and test databases |
-| `make generate-migration NAME=add-table` | Generate a new migration file |
+
+| Target                                   | Description                               |
+| ---------------------------------------- | ----------------------------------------- |
+| `make build-server`                      | Compile TypeScript                        |
+| `make build-client`                      | Build production client bundle            |
+| `make migrate`                           | Run database migrations                   |
+| `make migrate-all`                       | Run migrations for dev and test databases |
+| `make generate-migration NAME=add-table` | Generate a new migration file             |
 
 ### Logs
-| Target | Description |
-|--------|-------------|
-| `make logs` | Follow all container logs |
-| `make logs-server` | Follow server logs |
-| `make logs-client` | Follow client logs |
-| `make logs-worker` | Follow worker logs |
+
+| Target             | Description               |
+| ------------------ | ------------------------- |
+| `make logs`        | Follow all container logs |
+| `make logs-server` | Follow server logs        |
+| `make logs-client` | Follow client logs        |
 
 ## Project Structure
 
 ```
 ├── .claude/
-│   └── skills/              # Claude Code skills (create-model, create-endpoint, etc.)
+│   └── skills/              # Claude Code skills
 ├── .circleci/
-│   └── config.yml           # CircleCI CI/CD pipeline
-├── .github/
-│   └── workflows/
-│       └── create-release-pr.yml  # Automated release PR (develop -> main)
-├── client/                  # React frontend (Vite)
+│   └── config.yml           # CI/CD pipeline
+├── client/
 │   └── src/
-├── docker/
-│   └── postgres/            # PostgreSQL init scripts
-├── hooks/                   # Git pre-commit hooks
+│       ├── Components/      # Reusable React components
+│       ├── Contexts/        # React context providers (AuthContext)
+│       ├── Pages/           # Page components (Login, Signup, Dashboard)
+│       ├── Routes/          # React Router config, ProtectedRoute
+│       ├── Services/        # API client services (authService, apiClient)
+│       └── test/            # Test setup and helpers
 ├── scripts/
+│   ├── init-project.sh      # Project renaming script
 │   └── set-ports.sh         # Port auto-detection
 ├── server/
 │   └── src/
-│       ├── api/             # REST endpoints (routes, controllers, tests, docs)
+│       ├── api/             # REST endpoints (auth, healthCheck)
 │       ├── config/          # Environment and app configuration
-│       ├── db/              # Sequelize models, migrations, sequelize instance
+│       ├── db/              # Sequelize models, migrations
 │       ├── docs/            # OpenAPI/Swagger setup
 │       ├── lib/             # Business logic libraries
-│       ├── middleware/      # Express middleware (error handler)
+│       ├── middleware/       # Express middleware (error handler)
 │       ├── queue/           # BullMQ queue infrastructure (optional Redis)
-│       ├── scripts/         # Startup scripts (checkEnv, startWorker)
-│       ├── test/            # Test setup, helpers, data generators
-│       ├── logger.ts        # Environment-aware logging
-│       ├── server.ts        # Express app entry point
-│       └── worker.ts        # Background worker entry point
+│       └── test/            # Test setup, helpers, data generators
 ├── docker-compose.yaml
-└── Makefile
+├── Makefile
+└── README.md
 ```
 
 ## API Documentation
 
 Available at:
+
 - `/docs` — Interactive ReDoc UI
 - `/swagger.json` — Raw OpenAPI spec
-- `/api-docs` — JSON spec (alias)
 
-Each endpoint module has a co-located `.api.docs.yaml` file that is auto-discovered. See `server/src/api/healthCheck/` for the reference pattern.
+Each endpoint module has a co-located `.api.docs.yaml` file. See `server/src/api/auth/` for the reference pattern.
 
 ## Setting up CircleCI
 
 1. Sign up at https://circleci.com/ and connect your GitHub repository
-
 2. Add these environment variables in CircleCI project settings:
    - `DOCKERHUB_USERNAME` — Docker Hub username
    - `DOCKERHUB_PASSWORD` — Docker Hub access token
-
-3. For deployment, add your hosting provider's credentials (see `/deploy` skill for guided setup)
-
-4. The CI pipeline runs:
-   - Server build + tests (on `develop` and `main` branches)
-   - Server and client linting (on all branches)
-   - Client tests (on all branches)
-   - Deployment jobs (when hosting credentials are configured)
+3. The CI pipeline runs server build + tests, linting, and client tests
 
 ## Release Workflow
 
@@ -224,7 +230,7 @@ To create a release PR from `develop` to `main`:
 
 1. Create a feature branch from `develop`
 2. Make your changes
-3. Run `make lint-server && make test-server` before pushing
+3. Run `make prettier-all && make lint-server && make test-server` before pushing
 4. Submit a pull request to `develop`
 
 ## License

--- a/client/README.md
+++ b/client/README.md
@@ -24,7 +24,7 @@ export default tseslint.config({
   languageOptions: {
     // other options...
     parserOptions: {
-      project: ["./tsconfig.node.json", "./tsconfig.app.json"],
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
       tsconfigRootDir: import.meta.dirname,
     },
   },
@@ -35,19 +35,19 @@ You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-re
 
 ```js
 // eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config({
   plugins: {
     // Add the react-x and react-dom plugins
-    "react-x": reactX,
-    "react-dom": reactDom,
+    'react-x': reactX,
+    'react-dom': reactDom,
   },
   rules: {
     // other rules...
     // Enable its recommended typescript rules
-    ...reactX.configs["recommended-typescript"].rules,
+    ...reactX.configs['recommended-typescript'].rules,
     ...reactDom.configs.recommended.rules,
   },
 });

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,28 +1,25 @@
-import js from "@eslint/js";
-import globals from "globals";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import tseslint from "typescript-eslint";
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ["dist", "coverage"] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ["**/*.{ts,tsx}"],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": [
-        "warn",
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
 );

--- a/client/prettier.config.cjs
+++ b/client/prettier.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('prettier').Config} */
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+};

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
-import { Outlet } from "react-router-dom";
-import "./App.css";
-import Navbar from "./Components/Navbar/Navbar";
+import { Outlet } from 'react-router-dom';
+import './App.css';
+import Navbar from './Components/Navbar/Navbar';
 
 export default function App() {
   return (

--- a/client/src/Components/Counter.test.tsx
+++ b/client/src/Components/Counter.test.tsx
@@ -1,25 +1,25 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import React from "react";
-import { describe, expect, it } from "vitest";
-import Counter from "./Counter";
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import Counter from './Counter';
 
-describe("Counter", () => {
-  it("renders with initial count of 0", () => {
+describe('Counter', () => {
+  it('renders with initial count of 0', () => {
     render(<Counter />);
-    const button = screen.getByRole("button");
-    expect(button).toHaveTextContent("count is 0");
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('count is 0');
   });
 
-  it("increments count when clicked", () => {
+  it('increments count when clicked', () => {
     render(<Counter />);
-    const button = screen.getByRole("button");
+    const button = screen.getByRole('button');
 
     // Click once
     fireEvent.click(button);
-    expect(button).toHaveTextContent("count is 1");
+    expect(button).toHaveTextContent('count is 1');
 
     // Click again
     fireEvent.click(button);
-    expect(button).toHaveTextContent("count is 2");
+    expect(button).toHaveTextContent('count is 2');
   });
 });

--- a/client/src/Components/Counter.tsx
+++ b/client/src/Components/Counter.tsx
@@ -1,13 +1,9 @@
-import { useState } from "react";
+import { useState } from 'react';
 
 function Counter() {
   const [count, setCount] = useState(0);
 
-  return (
-    <button onClick={() => setCount((count) => count + 1)}>
-      count is {count}
-    </button>
-  );
+  return <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>;
 }
 
 export default Counter;

--- a/client/src/Components/Navbar/Navbar.test.tsx
+++ b/client/src/Components/Navbar/Navbar.test.tsx
@@ -1,17 +1,17 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { renderWithProviders } from "../../test/testHelpers";
-import Navbar from "./Navbar";
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test/testHelpers';
+import Navbar from './Navbar';
 
-describe("Navbar", () => {
-  it("shows login and signup links when not authenticated", () => {
+describe('Navbar', () => {
+  it('shows login and signup links when not authenticated', () => {
     renderWithProviders(<Navbar />);
-    expect(screen.getByRole("link", { name: "Log In" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Sign Up" })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Log In' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign Up' })).toBeInTheDocument();
   });
 
-  it("shows app brand link", () => {
+  it('shows app brand link', () => {
     renderWithProviders(<Navbar />);
-    expect(screen.getByRole("link", { name: "App" })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'App' })).toBeInTheDocument();
   });
 });

--- a/client/src/Components/Navbar/Navbar.tsx
+++ b/client/src/Components/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
-import { useAuth } from "../../Contexts/useAuth";
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../Contexts/useAuth';
 
 export default function Navbar() {
   const { isAuthenticated, user, logout } = useAuth();
@@ -13,9 +13,7 @@ export default function Navbar() {
         {isAuthenticated ? (
           <>
             <Link to="/dashboard">Dashboard</Link>
-            <span className="navbar-user">
-              {user?.displayName || user?.email}
-            </span>
+            <span className="navbar-user">{user?.displayName || user?.email}</span>
             <button onClick={logout} className="navbar-logout">
               Log Out
             </button>

--- a/client/src/Contexts/AuthProvider.tsx
+++ b/client/src/Contexts/AuthProvider.tsx
@@ -1,34 +1,30 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
-import * as authService from "../Services/authService";
-import type {
-  AuthResponse,
-  LoginParams,
-  SignupParams,
-} from "../Services/authService";
-import { AuthContext, AuthUser } from "./authContext";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import * as authService from '../Services/authService';
+import type { AuthResponse, LoginParams, SignupParams } from '../Services/authService';
+import { AuthContext, AuthUser } from './authContext';
 
 function loadStoredAuth(): { user: AuthUser | null; token: string | null } {
-  const token = localStorage.getItem("token");
-  const userJson = localStorage.getItem("user");
+  const token = localStorage.getItem('token');
+  const userJson = localStorage.getItem('user');
   if (token && userJson) {
     try {
       return { user: JSON.parse(userJson), token };
     } catch {
-      localStorage.removeItem("token");
-      localStorage.removeItem("user");
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
     }
   }
   return { user: null, token: null };
 }
 
 function saveAuth(response: AuthResponse) {
-  localStorage.setItem("token", response.token);
-  localStorage.setItem("user", JSON.stringify(response.user));
+  localStorage.setItem('token', response.token);
+  localStorage.setItem('user', JSON.stringify(response.user));
 }
 
 function clearAuth() {
-  localStorage.removeItem("token");
-  localStorage.removeItem("user");
+  localStorage.removeItem('token');
+  localStorage.removeItem('user');
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -66,8 +62,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const loginWithToken = useCallback((newToken: string, newUser: AuthUser) => {
-    localStorage.setItem("token", newToken);
-    localStorage.setItem("user", JSON.stringify(newUser));
+    localStorage.setItem('token', newToken);
+    localStorage.setItem('user', JSON.stringify(newUser));
     setToken(newToken);
     setUser(newUser);
   }, []);

--- a/client/src/Contexts/authContext.ts
+++ b/client/src/Contexts/authContext.ts
@@ -1,5 +1,5 @@
-import { createContext } from "react";
-import type { LoginParams, SignupParams } from "../Services/authService";
+import { createContext } from 'react';
+import type { LoginParams, SignupParams } from '../Services/authService';
 
 export interface AuthUser {
   id: string;

--- a/client/src/Contexts/useAuth.ts
+++ b/client/src/Contexts/useAuth.ts
@@ -1,10 +1,10 @@
-import { useContext } from "react";
-import { AuthContext, AuthContextValue } from "./authContext";
+import { useContext } from 'react';
+import { AuthContext, AuthContextValue } from './authContext';
 
 export function useAuth(): AuthContextValue {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error("useAuth must be used within an AuthProvider");
+    throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;
 }

--- a/client/src/Pages/DashboardPage/DashboardPage.test.tsx
+++ b/client/src/Pages/DashboardPage/DashboardPage.test.tsx
@@ -1,11 +1,11 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { renderWithProviders } from "../../test/testHelpers";
-import DashboardPage from "./DashboardPage";
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test/testHelpers';
+import DashboardPage from './DashboardPage';
 
-describe("DashboardPage", () => {
-  it("renders dashboard heading", () => {
+describe('DashboardPage', () => {
+  it('renders dashboard heading', () => {
     renderWithProviders(<DashboardPage />);
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 });

--- a/client/src/Pages/DashboardPage/DashboardPage.tsx
+++ b/client/src/Pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "../../Contexts/useAuth";
+import { useAuth } from '../../Contexts/useAuth';
 
 export default function DashboardPage() {
   const { user } = useAuth();

--- a/client/src/Pages/LoginPage/LoginPage.test.tsx
+++ b/client/src/Pages/LoginPage/LoginPage.test.tsx
@@ -1,21 +1,18 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { renderWithProviders } from "../../test/testHelpers";
-import LoginPage from "./LoginPage";
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test/testHelpers';
+import LoginPage from './LoginPage';
 
-describe("LoginPage", () => {
-  it("renders login form", () => {
-    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Log In" })).toBeInTheDocument();
+describe('LoginPage', () => {
+  it('renders login form', () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ['/login'] });
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Log In' })).toBeInTheDocument();
   });
 
-  it("has a link to signup page", () => {
-    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
-    expect(screen.getByRole("link", { name: "Sign up" })).toHaveAttribute(
-      "href",
-      "/signup",
-    );
+  it('has a link to signup page', () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ['/login'] });
+    expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
   });
 });

--- a/client/src/Pages/LoginPage/LoginPage.tsx
+++ b/client/src/Pages/LoginPage/LoginPage.tsx
@@ -1,17 +1,17 @@
-import { FormEvent, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { useAuth } from "../../Contexts/useAuth";
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../Contexts/useAuth';
 
 export default function LoginPage() {
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  const redirectTo = searchParams.get("redirectTo") || "/dashboard";
+  const redirectTo = searchParams.get('redirectTo') || '/dashboard';
 
   if (isAuthenticated) {
     navigate(decodeURIComponent(redirectTo), { replace: true });
@@ -20,18 +20,17 @@ export default function LoginPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    setError("");
+    setError('');
     setSubmitting(true);
     try {
       await login({ email, password });
       navigate(decodeURIComponent(redirectTo), { replace: true });
     } catch (err: unknown) {
       const message =
-        err && typeof err === "object" && "response" in err
-          ? (err as { response: { data: { error: string } } }).response?.data
-              ?.error
-          : "Login failed";
-      setError(message || "Login failed");
+        err && typeof err === 'object' && 'response' in err
+          ? (err as { response: { data: { error: string } } }).response?.data?.error
+          : 'Login failed';
+      setError(message || 'Login failed');
     } finally {
       setSubmitting(false);
     }
@@ -59,7 +58,7 @@ export default function LoginPage() {
           required
         />
         <button type="submit" disabled={submitting}>
-          {submitting ? "Logging in..." : "Log In"}
+          {submitting ? 'Logging in...' : 'Log In'}
         </button>
       </form>
       <p>

--- a/client/src/Pages/SignupPage/SignupPage.test.tsx
+++ b/client/src/Pages/SignupPage/SignupPage.test.tsx
@@ -1,23 +1,20 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { renderWithProviders } from "../../test/testHelpers";
-import SignupPage from "./SignupPage";
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test/testHelpers';
+import SignupPage from './SignupPage';
 
-describe("SignupPage", () => {
-  it("renders signup form", () => {
-    renderWithProviders(<SignupPage />, { initialEntries: ["/signup"] });
-    expect(screen.getByLabelText("First Name")).toBeInTheDocument();
-    expect(screen.getByLabelText("Last Name")).toBeInTheDocument();
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Sign Up" })).toBeInTheDocument();
+describe('SignupPage', () => {
+  it('renders signup form', () => {
+    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
+    expect(screen.getByLabelText('First Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Last Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign Up' })).toBeInTheDocument();
   });
 
-  it("has a link to login page", () => {
-    renderWithProviders(<SignupPage />, { initialEntries: ["/signup"] });
-    expect(screen.getByRole("link", { name: "Log in" })).toHaveAttribute(
-      "href",
-      "/login",
-    );
+  it('has a link to login page', () => {
+    renderWithProviders(<SignupPage />, { initialEntries: ['/signup'] });
+    expect(screen.getByRole('link', { name: 'Log in' })).toHaveAttribute('href', '/login');
   });
 });

--- a/client/src/Pages/SignupPage/SignupPage.tsx
+++ b/client/src/Pages/SignupPage/SignupPage.tsx
@@ -1,36 +1,35 @@
-import { FormEvent, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "../../Contexts/useAuth";
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../Contexts/useAuth';
 
 export default function SignupPage() {
   const { signup, isAuthenticated } = useAuth();
   const navigate = useNavigate();
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
   if (isAuthenticated) {
-    navigate("/dashboard", { replace: true });
+    navigate('/dashboard', { replace: true });
     return null;
   }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    setError("");
+    setError('');
     setSubmitting(true);
     try {
       await signup({ email, password, firstName, lastName });
-      navigate("/dashboard", { replace: true });
+      navigate('/dashboard', { replace: true });
     } catch (err: unknown) {
       const message =
-        err && typeof err === "object" && "response" in err
-          ? (err as { response: { data: { error: string } } }).response?.data
-              ?.error
-          : "Signup failed";
-      setError(message || "Signup failed");
+        err && typeof err === 'object' && 'response' in err
+          ? (err as { response: { data: { error: string } } }).response?.data?.error
+          : 'Signup failed';
+      setError(message || 'Signup failed');
     } finally {
       setSubmitting(false);
     }
@@ -75,7 +74,7 @@ export default function SignupPage() {
           minLength={8}
         />
         <button type="submit" disabled={submitting}>
-          {submitting ? "Signing up..." : "Sign Up"}
+          {submitting ? 'Signing up...' : 'Sign Up'}
         </button>
       </form>
       <p>

--- a/client/src/Routes/AppRoutes.tsx
+++ b/client/src/Routes/AppRoutes.tsx
@@ -1,14 +1,14 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import App from "../App";
-import { AuthProvider } from "../Contexts/AuthProvider";
-import DashboardPage from "../Pages/DashboardPage/DashboardPage";
-import LoginPage from "../Pages/LoginPage/LoginPage";
-import SignupPage from "../Pages/SignupPage/SignupPage";
-import ProtectedRoute from "./ProtectedRoute";
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import App from '../App';
+import { AuthProvider } from '../Contexts/AuthProvider';
+import DashboardPage from '../Pages/DashboardPage/DashboardPage';
+import LoginPage from '../Pages/LoginPage/LoginPage';
+import SignupPage from '../Pages/SignupPage/SignupPage';
+import ProtectedRoute from './ProtectedRoute';
 
 const router = createBrowserRouter([
   {
-    path: "/",
+    path: '/',
     element: (
       <AuthProvider>
         <App />
@@ -20,15 +20,15 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       {
-        path: "login",
+        path: 'login',
         element: <LoginPage />,
       },
       {
-        path: "signup",
+        path: 'signup',
         element: <SignupPage />,
       },
       {
-        path: "dashboard",
+        path: 'dashboard',
         element: (
           <ProtectedRoute>
             <DashboardPage />

--- a/client/src/Routes/ProtectedRoute.test.tsx
+++ b/client/src/Routes/ProtectedRoute.test.tsx
@@ -1,13 +1,13 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { AuthProvider } from "../Contexts/AuthProvider";
-import ProtectedRoute from "./ProtectedRoute";
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../Contexts/AuthProvider';
+import ProtectedRoute from './ProtectedRoute';
 
-describe("ProtectedRoute", () => {
-  it("redirects to login when not authenticated", () => {
+describe('ProtectedRoute', () => {
+  it('redirects to login when not authenticated', () => {
     render(
-      <MemoryRouter initialEntries={["/dashboard"]}>
+      <MemoryRouter initialEntries={['/dashboard']}>
         <AuthProvider>
           <Routes>
             <Route path="/login" element={<div>Login Page</div>} />
@@ -23,7 +23,7 @@ describe("ProtectedRoute", () => {
         </AuthProvider>
       </MemoryRouter>,
     );
-    expect(screen.queryByText("Secret Content")).not.toBeInTheDocument();
-    expect(screen.getByText("Login Page")).toBeInTheDocument();
+    expect(screen.queryByText('Secret Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
   });
 });

--- a/client/src/Routes/ProtectedRoute.tsx
+++ b/client/src/Routes/ProtectedRoute.tsx
@@ -1,11 +1,7 @@
-import { Navigate, useLocation } from "react-router-dom";
-import { useAuth } from "../Contexts/useAuth";
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../Contexts/useAuth';
 
-export default function ProtectedRoute({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, loading } = useAuth();
   const location = useLocation();
 

--- a/client/src/Services/apiClient.ts
+++ b/client/src/Services/apiClient.ts
@@ -1,11 +1,11 @@
-import axios from "axios";
+import axios from 'axios';
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_SERVER_BASE_URL,
 });
 
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }

--- a/client/src/Services/authService.ts
+++ b/client/src/Services/authService.ts
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from './apiClient';
 
 export interface AuthResponse {
   user: {
@@ -26,20 +26,17 @@ export interface LoginParams {
 }
 
 export async function signup(params: SignupParams): Promise<AuthResponse> {
-  const response = await apiClient.post<AuthResponse>(
-    "/v1/auth/signup",
-    params,
-  );
+  const response = await apiClient.post<AuthResponse>('/v1/auth/signup', params);
   return response.data;
 }
 
 export async function login(params: LoginParams): Promise<AuthResponse> {
-  const response = await apiClient.post<AuthResponse>("/v1/auth/login", params);
+  const response = await apiClient.post<AuthResponse>('/v1/auth/login', params);
   return response.data;
 }
 
 export async function googleAuth(credential: string): Promise<AuthResponse> {
-  const response = await apiClient.post<AuthResponse>("/v1/auth/google", {
+  const response = await apiClient.post<AuthResponse>('/v1/auth/google', {
     credential,
   });
   return response.data;

--- a/client/src/Services/userService.ts
+++ b/client/src/Services/userService.ts
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from './apiClient';
 
 export interface User {
   id: string;
@@ -10,13 +10,13 @@ export interface User {
 }
 
 export async function getMe(): Promise<User> {
-  const response = await apiClient.get<User>("/v1/users/me");
+  const response = await apiClient.get<User>('/v1/users/me');
   return response.data;
 }
 
 export async function updateUser(
   userId: string,
-  params: Partial<Pick<User, "displayName" | "firstName" | "lastName">>,
+  params: Partial<Pick<User, 'displayName' | 'firstName' | 'lastName'>>,
 ): Promise<User> {
   const response = await apiClient.put<User>(`/v1/users/${userId}`, params);
   return response.data;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import AppRoutes from "./Routes/AppRoutes";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import AppRoutes from './Routes/AppRoutes';
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AppRoutes />
   </StrictMode>,

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,6 +1,6 @@
-import "@testing-library/jest-dom";
-import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
 
 // Runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {

--- a/client/src/test/testHelpers.tsx
+++ b/client/src/test/testHelpers.tsx
@@ -1,7 +1,7 @@
-import { render, RenderOptions } from "@testing-library/react";
-import { ReactElement } from "react";
-import { MemoryRouter } from "react-router-dom";
-import { AuthProvider } from "../Contexts/AuthProvider";
+import { render, RenderOptions } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../Contexts/AuthProvider';
 
 export class PromiseResolver<T = unknown> {
   reject!: (value: T) => void;
@@ -18,10 +18,7 @@ export class PromiseResolver<T = unknown> {
 
 export function renderWithProviders(
   ui: ReactElement,
-  {
-    initialEntries = ["/"],
-    ...options
-  }: RenderOptions & { initialEntries?: string[] } = {},
+  { initialEntries = ['/'], ...options }: RenderOptions & { initialEntries?: string[] } = {},
 ) {
   function Wrapper({ children }: { children: React.ReactNode }) {
     return (

--- a/client/vite.config.d.ts
+++ b/client/vite.config.d.ts
@@ -1,2 +1,2 @@
-declare const _default: import("vite").UserConfig;
+declare const _default: import('vite').UserConfig;
 export default _default;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,10 +1,10 @@
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: "0.0.0.0",
+    host: '0.0.0.0',
     port: 3000,
     hmr: {
       port: 3010,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,14 +1,14 @@
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: "0.0.0.0",
+    host: '0.0.0.0',
     port: 3000,
     hmr: {
-      port: parseInt(process.env.VITE_HMR_PORT || "3010"),
+      port: parseInt(process.env.VITE_HMR_PORT || '3010'),
     },
   },
 });

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,11 +1,11 @@
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vitest/config";
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: "jsdom", // Simulates a browser environment
+    environment: 'jsdom', // Simulates a browser environment
     globals: true,
-    setupFiles: ["./src/test/setup.ts"],
+    setupFiles: ['./src/test/setup.ts'],
   },
 });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     user: postgres
     build: ./docker/postgres
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - '${POSTGRES_PORT:-5432}:5432'
     volumes:
       - ./docker/postgres:/docker-entrypoint-initdb.d
     environment:
@@ -17,19 +17,19 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: pass
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready","-u", "postgres", "-d", "serverdev"]
+      test: ['CMD-SHELL', 'pg_isready', '-u', 'postgres', '-d', 'serverdev']
       interval: 1s
       timeout: 60s
       retries: 5
-      start_period: 80s  
+      start_period: 80s
 
   server:
     build:
       context: ./server
       dockerfile: Dockerfile
     ports:
-      - "127.0.0.1:${SERVER_PORT:-10020}:10020"
-      - "127.0.0.1:${SERVER_DEBUG_PORT:-9229}:9229"
+      - '127.0.0.1:${SERVER_PORT:-10020}:10020'
+      - '127.0.0.1:${SERVER_DEBUG_PORT:-9229}:9229'
     expose:
       - 9229
     volumes:
@@ -40,15 +40,14 @@ services:
       - migrate
     env_file:
       - ./server/.env
-    command:
-      ["npm", "run", "dev"]
+    command: ['npm', 'run', 'dev']
 
   worker:
     build:
       context: ./server
       dockerfile: Dockerfile
     ports:
-      - "127.0.0.1:${WORKER_PORT:-10030}:10030"
+      - '127.0.0.1:${WORKER_PORT:-10030}:10030'
     expose:
       - 9229
     volumes:
@@ -61,8 +60,7 @@ services:
       - migrate
     env_file:
       - ./server/.env
-    command:
-      ["npm", "run", "worker"]
+    command: ['npm', 'run', 'worker']
 
   migrate:
     build:
@@ -74,13 +72,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-        
+
     env_file:
       - ./server/.env
-    command: ["npm", "run", "migrate:all"]
+    command: ['npm', 'run', 'migrate:all']
 
   client:
-    build: 
+    build:
       context: ./client
       dockerfile: Dockerfile
     command: npm run dev
@@ -91,5 +89,5 @@ services:
       - path: ./client/.env
         required: false
     ports:
-      - "${CLIENT_PORT:-3000}:3000"
-      - "${CLIENT_HMR_PORT:-3010}:3010"
+      - '${CLIENT_PORT:-3000}:3000'
+      - '${CLIENT_HMR_PORT:-3010}:3010'

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -8,9 +8,9 @@ This guide provides an overview of the API, its core concepts, and how to use it
 
 ## Base URLs
 
-| Environment | URL |
-|-------------|-----|
-| Development | http://localhost:10020 |
+| Environment | URL                         |
+| ----------- | --------------------------- |
+| Development | http://localhost:10020      |
 | Production  | https://api.your-domain.com |
 
 All API endpoints are prefixed with `/v1/` to indicate the API version.
@@ -85,16 +85,16 @@ All API errors follow a consistent format:
 
 **Common HTTP status codes:**
 
-| Status | Description |
-|--------|-------------|
-| 200 | Success |
-| 201 | Resource created |
-| 400 | Bad request (invalid parameters) |
-| 401 | Unauthorized (authentication required) |
-| 403 | Forbidden (insufficient permissions) |
-| 404 | Resource not found |
-| 409 | Conflict (e.g., resource already exists) |
-| 500 | Server error |
+| Status | Description                              |
+| ------ | ---------------------------------------- |
+| 200    | Success                                  |
+| 201    | Resource created                         |
+| 400    | Bad request (invalid parameters)         |
+| 401    | Unauthorized (authentication required)   |
+| 403    | Forbidden (insufficient permissions)     |
+| 404    | Resource not found                       |
+| 409    | Conflict (e.g., resource already exists) |
+| 500    | Server error                             |
 
 ## Best Practices
 

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCAFFOLD_NAME="node-react-scaffold"
+
+echo "=== Project Initializer ==="
+echo ""
+
+# Prompt for project name
+read -rp "Project name (kebab-case, e.g. my-cool-app): " PROJECT_NAME
+
+if [ -z "$PROJECT_NAME" ]; then
+  echo "Error: Project name cannot be empty" >&2
+  exit 1
+fi
+
+# Validate kebab-case
+if ! echo "$PROJECT_NAME" | grep -qE '^[a-z][a-z0-9-]*$'; then
+  echo "Error: Project name must be kebab-case (lowercase letters, numbers, hyphens)" >&2
+  exit 1
+fi
+
+echo ""
+echo "Renaming project from '$SCAFFOLD_NAME' to '$PROJECT_NAME'..."
+
+# Root package.json
+sed -i '' "s/\"name\": \"$SCAFFOLD_NAME\"/\"name\": \"$PROJECT_NAME\"/" package.json
+
+# README title
+sed -i '' "s/^# Node\/React Scaffold/# $PROJECT_NAME/" README.md
+
+# COMPOSE_PROJECT_NAME in .env-example (used on first install)
+if [ -f .env-example ]; then
+  sed -i '' "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=$PROJECT_NAME/" .env-example
+fi
+
+# COMPOSE_PROJECT_NAME in .env (if already created)
+if [ -f .env ]; then
+  sed -i '' "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=$PROJECT_NAME/" .env
+fi
+
+# API docs title
+DOCS_FILE="server/src/docs/index.ts"
+if [ -f "$DOCS_FILE" ]; then
+  sed -i '' "s/title: \"API Documentation\"/title: \"$PROJECT_NAME API\"/" "$DOCS_FILE"
+fi
+
+echo ""
+echo "Done! Updated:"
+echo "  - package.json (name)"
+echo "  - README.md (title)"
+echo "  - .env / .env-example (COMPOSE_PROJECT_NAME)"
+echo "  - server/src/docs/index.ts (API title)"
+echo ""
+echo "Next steps:"
+echo "  1. make install"
+echo "  2. make launch"
+echo "  3. Open http://localhost:3000"

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -1,9 +1,9 @@
-const eslint = require("@eslint/js");
-const tseslint = require("typescript-eslint");
+const eslint = require('@eslint/js');
+const tseslint = require('typescript-eslint');
 module.exports = tseslint.config({
-  files: ["**/*.ts"],
+  files: ['**/*.ts'],
   extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
   rules: {
-    "@typescript-eslint/no-unused-vars": "warn",
+    '@typescript-eslint/no-unused-vars': 'warn',
   },
 });

--- a/server/prettier.config.cjs
+++ b/server/prettier.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('prettier').Config} */
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+};

--- a/server/src/api/auth/auth.api.docs.yaml
+++ b/server/src/api/auth/auth.api.docs.yaml
@@ -31,7 +31,7 @@ paths:
                   type: string
                   example: Doe
       responses:
-        "201":
+        '201':
           description: User created successfully
           content:
             application/json:
@@ -39,12 +39,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/UserJwtRepr"
+                    $ref: '#/components/schemas/UserJwtRepr'
                   token:
                     type: string
-        "400":
+        '400':
           description: Missing required fields
-        "409":
+        '409':
           description: A user with this email already exists
 
   /v1/auth/login:
@@ -71,7 +71,7 @@ paths:
                   type: string
                   example: mypassword123
       responses:
-        "200":
+        '200':
           description: Login successful
           content:
             application/json:
@@ -79,12 +79,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/UserJwtRepr"
+                    $ref: '#/components/schemas/UserJwtRepr'
                   token:
                     type: string
-        "400":
+        '400':
           description: Missing required fields
-        "401":
+        '401':
           description: Invalid email or password
 
   /v1/auth/google:
@@ -108,7 +108,7 @@ paths:
                   type: string
                   description: Google ID token from client-side sign-in
       responses:
-        "200":
+        '200':
           description: Authentication successful
           content:
             application/json:
@@ -116,12 +116,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/UserJwtRepr"
+                    $ref: '#/components/schemas/UserJwtRepr'
                   token:
                     type: string
-        "400":
+        '400':
           description: Google sign-in not configured or missing idToken
-        "401":
+        '401':
           description: Invalid Google ID token
 
 components:

--- a/server/src/api/auth/auth.api.test.ts
+++ b/server/src/api/auth/auth.api.test.ts
@@ -1,136 +1,132 @@
-import { assert } from "chai";
-import * as sinon from "sinon";
-import request from "supertest";
-import * as bcrypt from "bcrypt";
-import { LoginTicket, OAuth2Client, TokenPayload } from "google-auth-library";
-import app from "../../server";
-import User from "../../db/models/user.model";
-import config from "../../config/config";
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import request from 'supertest';
+import * as bcrypt from 'bcrypt';
+import { LoginTicket, OAuth2Client, TokenPayload } from 'google-auth-library';
+import app from '../../server';
+import User from '../../db/models/user.model';
+import config from '../../config/config';
 
 function mockTicket(payload: TokenPayload): LoginTicket {
   const ticket = new LoginTicket();
-  sinon.stub(ticket, "getPayload").returns(payload);
+  sinon.stub(ticket, 'getPayload').returns(payload);
   return ticket;
 }
 
-describe("Auth API", function () {
-  describe("POST /v1/auth/signup", function () {
-    it("creates a new user and returns a token", function (done) {
+describe('Auth API', function () {
+  describe('POST /v1/auth/signup', function () {
+    it('creates a new user and returns a token', function (done) {
       request(app)
-        .post("/v1/auth/signup")
+        .post('/v1/auth/signup')
         .send({
-          email: "test@example.com",
-          password: "password123",
-          firstName: "Test",
-          lastName: "User",
+          email: 'test@example.com',
+          password: 'password123',
+          firstName: 'Test',
+          lastName: 'User',
         })
         .expect(201)
         .end(function (err, res) {
           if (err) return done(err);
           assert.exists(res.body.token);
-          assert.equal(res.body.user.email, "test@example.com");
-          assert.equal(res.body.user.firstName, "Test");
-          assert.equal(res.body.user.lastName, "User");
-          assert.equal(res.body.user.role, "user");
+          assert.equal(res.body.user.email, 'test@example.com');
+          assert.equal(res.body.user.firstName, 'Test');
+          assert.equal(res.body.user.lastName, 'User');
+          assert.equal(res.body.user.role, 'user');
           assert.exists(res.body.user.id);
           done();
         });
     });
 
-    it("hashes the password", async function () {
-      await request(app).post("/v1/auth/signup").send({
-        email: "hash@example.com",
-        password: "password123",
-        firstName: "Hash",
+    it('hashes the password', async function () {
+      await request(app).post('/v1/auth/signup').send({
+        email: 'hash@example.com',
+        password: 'password123',
+        firstName: 'Hash',
       });
 
-      const user = await User.findOne({ where: { email: "hash@example.com" } });
+      const user = await User.findOne({ where: { email: 'hash@example.com' } });
       assert.exists(user?.passwordHash);
-      assert.notEqual(user!.passwordHash, "password123");
-      const matches = await bcrypt.compare("password123", user!.passwordHash!);
+      assert.notEqual(user!.passwordHash, 'password123');
+      const matches = await bcrypt.compare('password123', user!.passwordHash!);
       assert.isTrue(matches);
     });
 
-    it("returns 409 if email already exists", async function () {
-      await request(app).post("/v1/auth/signup").send({
-        email: "dupe@example.com",
-        password: "password123",
-        firstName: "First",
+    it('returns 409 if email already exists', async function () {
+      await request(app).post('/v1/auth/signup').send({
+        email: 'dupe@example.com',
+        password: 'password123',
+        firstName: 'First',
       });
 
-      const res = await request(app).post("/v1/auth/signup").send({
-        email: "dupe@example.com",
-        password: "password456",
-        firstName: "Second",
+      const res = await request(app).post('/v1/auth/signup').send({
+        email: 'dupe@example.com',
+        password: 'password456',
+        firstName: 'Second',
       });
 
       assert.equal(res.status, 409);
     });
 
-    it("returns 400 if required fields are missing", async function () {
-      const res = await request(app)
-        .post("/v1/auth/signup")
-        .send({ email: "test@example.com" });
+    it('returns 400 if required fields are missing', async function () {
+      const res = await request(app).post('/v1/auth/signup').send({ email: 'test@example.com' });
 
       assert.equal(res.status, 400);
     });
   });
 
-  describe("POST /v1/auth/login", function () {
+  describe('POST /v1/auth/login', function () {
     beforeEach(async function () {
-      const passwordHash = await bcrypt.hash("password123", 10);
+      const passwordHash = await bcrypt.hash('password123', 10);
       await User.create({
-        email: "login@example.com",
-        firstName: "Login",
-        lastName: "User",
+        email: 'login@example.com',
+        firstName: 'Login',
+        lastName: 'User',
         passwordHash,
       });
     });
 
-    it("logs in with correct credentials", function (done) {
+    it('logs in with correct credentials', function (done) {
       request(app)
-        .post("/v1/auth/login")
-        .send({ email: "login@example.com", password: "password123" })
+        .post('/v1/auth/login')
+        .send({ email: 'login@example.com', password: 'password123' })
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err);
           assert.exists(res.body.token);
-          assert.equal(res.body.user.email, "login@example.com");
-          assert.equal(res.body.user.firstName, "Login");
+          assert.equal(res.body.user.email, 'login@example.com');
+          assert.equal(res.body.user.firstName, 'Login');
           done();
         });
     });
 
-    it("returns 401 for wrong password", async function () {
+    it('returns 401 for wrong password', async function () {
       const res = await request(app)
-        .post("/v1/auth/login")
-        .send({ email: "login@example.com", password: "wrongpassword" });
+        .post('/v1/auth/login')
+        .send({ email: 'login@example.com', password: 'wrongpassword' });
 
       assert.equal(res.status, 401);
     });
 
-    it("returns 401 for non-existent email", async function () {
+    it('returns 401 for non-existent email', async function () {
       const res = await request(app)
-        .post("/v1/auth/login")
-        .send({ email: "nobody@example.com", password: "password123" });
+        .post('/v1/auth/login')
+        .send({ email: 'nobody@example.com', password: 'password123' });
 
       assert.equal(res.status, 401);
     });
 
-    it("returns 400 if required fields are missing", async function () {
-      const res = await request(app)
-        .post("/v1/auth/login")
-        .send({ email: "login@example.com" });
+    it('returns 400 if required fields are missing', async function () {
+      const res = await request(app).post('/v1/auth/login').send({ email: 'login@example.com' });
 
       assert.equal(res.status, 400);
     });
   });
 
-  describe("POST /v1/auth/google", function () {
+  describe('POST /v1/auth/google', function () {
     const originalGoogleClientId = config.GOOGLE_CLIENT_ID;
 
     beforeEach(function () {
-      config.GOOGLE_CLIENT_ID = "test-google-client-id";
+      config.GOOGLE_CLIENT_ID = 'test-google-client-id';
     });
 
     afterEach(function () {
@@ -138,92 +134,86 @@ describe("Auth API", function () {
       sinon.restore();
     });
 
-    it("creates a new user from Google token", async function () {
-      sinon.stub(OAuth2Client.prototype, "verifyIdToken").resolves(
+    it('creates a new user from Google token', async function () {
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
         mockTicket({
-          email: "google@example.com",
+          email: 'google@example.com',
           email_verified: true,
-          given_name: "Google",
-          family_name: "User",
-          picture: "https://example.com/photo.jpg",
-          sub: "google-user-id-123",
-          aud: "test-google-client-id",
+          given_name: 'Google',
+          family_name: 'User',
+          picture: 'https://example.com/photo.jpg',
+          sub: 'google-user-id-123',
+          aud: 'test-google-client-id',
           exp: Math.floor(Date.now() / 1000) + 3600,
           iat: Math.floor(Date.now() / 1000),
-          iss: "accounts.google.com",
+          iss: 'accounts.google.com',
         }),
       );
 
       const res = await request(app)
-        .post("/v1/auth/google")
-        .send({ idToken: "valid-google-token" });
+        .post('/v1/auth/google')
+        .send({ idToken: 'valid-google-token' });
 
       assert.equal(res.status, 200);
       assert.exists(res.body.token);
-      assert.equal(res.body.user.email, "google@example.com");
-      assert.equal(res.body.user.firstName, "Google");
-      assert.equal(res.body.user.lastName, "User");
+      assert.equal(res.body.user.email, 'google@example.com');
+      assert.equal(res.body.user.firstName, 'Google');
+      assert.equal(res.body.user.lastName, 'User');
     });
 
-    it("logs in existing user with matching email", async function () {
+    it('logs in existing user with matching email', async function () {
       await User.create({
-        email: "existing@example.com",
-        firstName: "Existing",
-        lastName: "User",
+        email: 'existing@example.com',
+        firstName: 'Existing',
+        lastName: 'User',
       });
 
-      sinon.stub(OAuth2Client.prototype, "verifyIdToken").resolves(
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').resolves(
         mockTicket({
-          email: "existing@example.com",
+          email: 'existing@example.com',
           email_verified: true,
-          given_name: "Existing",
-          family_name: "User",
-          sub: "google-user-id-456",
-          aud: "test-google-client-id",
+          given_name: 'Existing',
+          family_name: 'User',
+          sub: 'google-user-id-456',
+          aud: 'test-google-client-id',
           exp: Math.floor(Date.now() / 1000) + 3600,
           iat: Math.floor(Date.now() / 1000),
-          iss: "accounts.google.com",
+          iss: 'accounts.google.com',
         }),
       );
 
       const res = await request(app)
-        .post("/v1/auth/google")
-        .send({ idToken: "valid-google-token" });
+        .post('/v1/auth/google')
+        .send({ idToken: 'valid-google-token' });
 
       assert.equal(res.status, 200);
       assert.exists(res.body.token);
-      assert.equal(res.body.user.email, "existing@example.com");
+      assert.equal(res.body.user.email, 'existing@example.com');
 
       const users = await User.findAll({
-        where: { email: "existing@example.com" },
+        where: { email: 'existing@example.com' },
       });
       assert.equal(users.length, 1);
     });
 
-    it("returns 400 if GOOGLE_CLIENT_ID is not set", async function () {
+    it('returns 400 if GOOGLE_CLIENT_ID is not set', async function () {
       config.GOOGLE_CLIENT_ID = undefined;
 
-      const res = await request(app)
-        .post("/v1/auth/google")
-        .send({ idToken: "some-token" });
+      const res = await request(app).post('/v1/auth/google').send({ idToken: 'some-token' });
 
       assert.equal(res.status, 400);
     });
 
-    it("returns 401 for invalid token", async function () {
-      sinon
-        .stub(OAuth2Client.prototype, "verifyIdToken")
-        .rejects(new Error("Invalid token"));
+    it('returns 401 for invalid token', async function () {
+      sinon.stub(OAuth2Client.prototype, 'verifyIdToken').rejects(new Error('Invalid token'));
 
-      const res = await request(app)
-        .post("/v1/auth/google")
-        .send({ idToken: "invalid-token" });
+      const res = await request(app).post('/v1/auth/google').send({ idToken: 'invalid-token' });
 
       assert.equal(res.status, 401);
     });
 
-    it("returns 400 if idToken is missing", async function () {
-      const res = await request(app).post("/v1/auth/google").send({});
+    it('returns 400 if idToken is missing', async function () {
+      const res = await request(app).post('/v1/auth/google').send({});
 
       assert.equal(res.status, 400);
     });

--- a/server/src/api/auth/auth.api.ts
+++ b/server/src/api/auth/auth.api.ts
@@ -1,11 +1,7 @@
-import { NextFunction, Request, Response } from "express";
-import { googleSignIn, login, signup } from "../../lib/auth";
+import { NextFunction, Request, Response } from 'express';
+import { googleSignIn, login, signup } from '../../lib/auth';
 
-export async function handleSignup(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+export async function handleSignup(req: Request, res: Response, next: NextFunction) {
   try {
     const { email, password, firstName, lastName } = req.body;
     const { user, token } = await signup({
@@ -20,11 +16,7 @@ export async function handleSignup(
   }
 }
 
-export async function handleLogin(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+export async function handleLogin(req: Request, res: Response, next: NextFunction) {
   try {
     const { email, password } = req.body;
     const { user, token } = await login({ email, password });
@@ -34,11 +26,7 @@ export async function handleLogin(
   }
 }
 
-export async function handleGoogleSignIn(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+export async function handleGoogleSignIn(req: Request, res: Response, next: NextFunction) {
   try {
     const { idToken } = req.body;
     const { user, token } = await googleSignIn({ idToken });

--- a/server/src/api/auth/index.ts
+++ b/server/src/api/auth/index.ts
@@ -1,17 +1,13 @@
-import express from "express";
-import { checkBodyFor } from "../validation";
-import { handleGoogleSignIn, handleLogin, handleSignup } from "./auth.api";
+import express from 'express';
+import { checkBodyFor } from '../validation';
+import { handleGoogleSignIn, handleLogin, handleSignup } from './auth.api';
 
 const router = express.Router();
 
-router.post(
-  "/signup",
-  checkBodyFor(["email", "password", "firstName"]),
-  handleSignup,
-);
+router.post('/signup', checkBodyFor(['email', 'password', 'firstName']), handleSignup);
 
-router.post("/login", checkBodyFor(["email", "password"]), handleLogin);
+router.post('/login', checkBodyFor(['email', 'password']), handleLogin);
 
-router.post("/google", checkBodyFor(["idToken"]), handleGoogleSignIn);
+router.post('/google', checkBodyFor(['idToken']), handleGoogleSignIn);
 
 export default router;

--- a/server/src/api/healthCheck/healthCheck.api.docs.yaml
+++ b/server/src/api/healthCheck/healthCheck.api.docs.yaml
@@ -6,7 +6,7 @@
     description: Returns the health status of the API
     operationId: healthCheck
     responses:
-      "200":
+      '200':
         description: Successful health check response
         content:
           application/json:
@@ -18,7 +18,7 @@
                   example: true
               required:
                 - healthy
-      "500":
+      '500':
         description: Server error
         content:
           application/json:

--- a/server/src/api/healthCheck/healthCheck.api.test.ts
+++ b/server/src/api/healthCheck/healthCheck.api.test.ts
@@ -1,13 +1,13 @@
-import { assert } from "chai";
-import request from "supertest";
+import { assert } from 'chai';
+import request from 'supertest';
 
-import app from "../../server";
+import app from '../../server';
 
-describe("Authorization and Authentication", function () {
-  describe("HealthCheck", function () {
-    it("checks the health", function (done) {
+describe('Authorization and Authentication', function () {
+  describe('HealthCheck', function () {
+    it('checks the health', function (done) {
       request(app)
-        .get("/v1/healthCheck")
+        .get('/v1/healthCheck')
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err);

--- a/server/src/api/healthCheck/healthCheck.api.ts
+++ b/server/src/api/healthCheck/healthCheck.api.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from "express";
+import { RequestHandler } from 'express';
 
 const healthCheckEndpoint: RequestHandler = (_req, res) => {
   res.status(200).json({ healthy: true });

--- a/server/src/api/healthCheck/index.ts
+++ b/server/src/api/healthCheck/index.ts
@@ -1,9 +1,9 @@
-import express from "express";
-import controller from "./healthCheck.api";
+import express from 'express';
+import controller from './healthCheck.api';
 
 const router = express.Router();
 
-router.get("/", controller.healthCheckEndpoint);
+router.get('/', controller.healthCheckEndpoint);
 
 // To use middleware, it would be something like
 /*

--- a/server/src/api/routes.ts
+++ b/server/src/api/routes.ts
@@ -1,10 +1,10 @@
-import { Application } from "express";
-import authApi from "./auth";
-import healthCheckApi from "./healthCheck";
+import { Application } from 'express';
+import authApi from './auth';
+import healthCheckApi from './healthCheck';
 
 function addRoutes(app: Application) {
-  app.use("/v1/auth", authApi);
-  app.use("/v1/healthCheck", healthCheckApi);
+  app.use('/v1/auth', authApi);
+  app.use('/v1/healthCheck', healthCheckApi);
 }
 
 export default addRoutes;

--- a/server/src/api/security.test.ts
+++ b/server/src/api/security.test.ts
@@ -1,15 +1,15 @@
-import { assert } from "chai";
-import { Request, Response } from "express";
-import { PermissionError } from "../utils/errors";
+import { assert } from 'chai';
+import { Request, Response } from 'express';
+import { PermissionError } from '../utils/errors';
 import {
   requireRoleOfAtLeast,
   isOperatingOnSelf,
   ROLE_HIERARCHY,
   AuthenticatedRequest,
-} from "./security";
+} from './security';
 
 function mockAuthReq(
-  auth: Partial<AuthenticatedRequest["auth"]>,
+  auth: Partial<AuthenticatedRequest['auth']>,
   overrides: Partial<Request> = {},
 ): Request {
   return {
@@ -18,9 +18,9 @@ function mockAuthReq(
     body: {},
     headers: {},
     auth: {
-      id: "user-123",
-      email: "test@test.com",
-      role: "user",
+      id: 'user-123',
+      email: 'test@test.com',
+      role: 'user',
       ...auth,
     },
     ...overrides,
@@ -31,54 +31,54 @@ function mockRes(): Response {
   return {} as Response;
 }
 
-describe("Security Middleware", function () {
-  describe("ROLE_HIERARCHY", function () {
-    it("should define guest < user < admin", function () {
+describe('Security Middleware', function () {
+  describe('ROLE_HIERARCHY', function () {
+    it('should define guest < user < admin', function () {
       assert.isBelow(ROLE_HIERARCHY.guest, ROLE_HIERARCHY.user);
       assert.isBelow(ROLE_HIERARCHY.user, ROLE_HIERARCHY.admin);
     });
   });
 
-  describe("requireRoleOfAtLeast", function () {
-    it("should pass when user has the required role", function (done) {
-      const middleware = requireRoleOfAtLeast("user");
-      const req = mockAuthReq({ role: "user" });
+  describe('requireRoleOfAtLeast', function () {
+    it('should pass when user has the required role', function (done) {
+      const middleware = requireRoleOfAtLeast('user');
+      const req = mockAuthReq({ role: 'user' });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should pass when user has a higher role than required", function (done) {
-      const middleware = requireRoleOfAtLeast("user");
-      const req = mockAuthReq({ role: "admin" });
+    it('should pass when user has a higher role than required', function (done) {
+      const middleware = requireRoleOfAtLeast('user');
+      const req = mockAuthReq({ role: 'admin' });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when user has a lower role than required", function (done) {
-      const middleware = requireRoleOfAtLeast("admin");
-      const req = mockAuthReq({ role: "user" });
+    it('should fail when user has a lower role than required', function (done) {
+      const middleware = requireRoleOfAtLeast('admin');
+      const req = mockAuthReq({ role: 'user' });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, PermissionError);
         done();
       });
     });
 
-    it("should fail when user has guest role and user is required", function (done) {
-      const middleware = requireRoleOfAtLeast("user");
-      const req = mockAuthReq({ role: "guest" });
+    it('should fail when user has guest role and user is required', function (done) {
+      const middleware = requireRoleOfAtLeast('user');
+      const req = mockAuthReq({ role: 'guest' });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, PermissionError);
         done();
       });
     });
 
-    it("should pass guest for guest-level access", function (done) {
-      const middleware = requireRoleOfAtLeast("guest");
-      const req = mockAuthReq({ role: "guest" });
+    it('should pass guest for guest-level access', function (done) {
+      const middleware = requireRoleOfAtLeast('guest');
+      const req = mockAuthReq({ role: 'guest' });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
@@ -86,46 +86,40 @@ describe("Security Middleware", function () {
     });
   });
 
-  describe("isOperatingOnSelf", function () {
-    it("should pass when user operates on themselves (params)", function (done) {
-      const middleware = isOperatingOnSelf("userId");
-      const req = mockAuthReq(
-        { id: "user-123" },
-        { params: { userId: "user-123" } },
-      );
+  describe('isOperatingOnSelf', function () {
+    it('should pass when user operates on themselves (params)', function (done) {
+      const middleware = isOperatingOnSelf('userId');
+      const req = mockAuthReq({ id: 'user-123' }, { params: { userId: 'user-123' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when user operates on another user (params)", function (done) {
-      const middleware = isOperatingOnSelf("userId");
-      const req = mockAuthReq(
-        { id: "user-123" },
-        { params: { userId: "user-456" } },
-      );
+    it('should fail when user operates on another user (params)', function (done) {
+      const middleware = isOperatingOnSelf('userId');
+      const req = mockAuthReq({ id: 'user-123' }, { params: { userId: 'user-456' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, PermissionError);
-        assert.include((err as Error).message, "your own account");
+        assert.include((err as Error).message, 'your own account');
         done();
       });
     });
 
-    it("should pass when user operates on themselves (body)", function (done) {
-      const middleware = isOperatingOnSelf("userId", "body");
-      const req = mockAuthReq({ id: "user-123" });
-      req.body = { userId: "user-123" };
+    it('should pass when user operates on themselves (body)', function (done) {
+      const middleware = isOperatingOnSelf('userId', 'body');
+      const req = mockAuthReq({ id: 'user-123' });
+      req.body = { userId: 'user-123' };
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when user operates on another user (body)", function (done) {
-      const middleware = isOperatingOnSelf("userId", "body");
-      const req = mockAuthReq({ id: "user-123" });
-      req.body = { userId: "user-456" };
+    it('should fail when user operates on another user (body)', function (done) {
+      const middleware = isOperatingOnSelf('userId', 'body');
+      const req = mockAuthReq({ id: 'user-123' });
+      req.body = { userId: 'user-456' };
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, PermissionError);
         done();

--- a/server/src/api/security.ts
+++ b/server/src/api/security.ts
@@ -1,20 +1,16 @@
-import { NextFunction, Request, Response } from "express";
-import { expressjwt } from "express-jwt";
-import config from "../config/config";
-import {
-  AuthenticationError,
-  ErrorMessages,
-  PermissionError,
-} from "../utils/errors";
+import { NextFunction, Request, Response } from 'express';
+import { expressjwt } from 'express-jwt';
+import config from '../config/config';
+import { AuthenticationError, ErrorMessages, PermissionError } from '../utils/errors';
 
 if (!config.JWT_SECRET) {
-  throw new Error("JWT_SECRET is required");
+  throw new Error('JWT_SECRET is required');
 }
 
 const jwt = expressjwt({
   secret: config.JWT_SECRET,
-  algorithms: ["HS256"],
-  requestProperty: "auth",
+  algorithms: ['HS256'],
+  requestProperty: 'auth',
 });
 
 export interface AuthenticatedRequest extends Request {
@@ -25,7 +21,7 @@ export interface AuthenticatedRequest extends Request {
     displayName?: string;
     email: string;
     profileImageUrl?: string;
-    role: "admin" | "user" | "guest";
+    role: 'admin' | 'user' | 'guest';
     [key: string]: string | number | undefined;
   };
 }
@@ -38,15 +34,10 @@ export const ROLE_HIERARCHY = {
 
 type UserRole = keyof typeof ROLE_HIERARCHY;
 
-export function authenticate(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): void {
-  const authHeader = (req.headers.authorization ||
-    req.headers.Authorization) as string;
+export function authenticate(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = (req.headers.authorization || req.headers.Authorization) as string;
 
-  const basicTokens = config.BASIC_AUTH_TOKENS?.split(" ");
+  const basicTokens = config.BASIC_AUTH_TOKENS?.split(' ');
   if (basicTokens && authHeader) {
     for (const token of basicTokens) {
       if (authHeader === `Basic ${token}`) {
@@ -58,11 +49,7 @@ export function authenticate(
   authenticateAccessToken(req, res, next);
 }
 
-export function authenticateAccessToken(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+export function authenticateAccessToken(req: Request, res: Response, next: NextFunction) {
   jwt(req, res, (err) => {
     if (err) {
       return next(new AuthenticationError(ErrorMessages.ACCESS_TOKEN_REQUIRED));
@@ -70,11 +57,11 @@ export function authenticateAccessToken(
 
     const authReq = req as AuthenticatedRequest;
     if (!authReq.auth) {
-      return next(new AuthenticationError("No auth data in token"));
+      return next(new AuthenticationError('No auth data in token'));
     }
 
     Object.keys(req.params).forEach((paramName) => {
-      if (req.params[paramName] === "me") {
+      if (req.params[paramName] === 'me') {
         req.params[paramName] = authReq.auth.id;
       }
     });
@@ -90,7 +77,7 @@ export function requireRoleOfAtLeast(minimumRole: UserRole) {
       const userRole = authReq.auth?.role as UserRole;
 
       if (!userRole || !(userRole in ROLE_HIERARCHY)) {
-        next(new PermissionError("Invalid user role"));
+        next(new PermissionError('Invalid user role'));
         return;
       }
 
@@ -109,22 +96,14 @@ export function requireRoleOfAtLeast(minimumRole: UserRole) {
   };
 }
 
-export function isOperatingOnSelf(
-  paramName: string,
-  source: "params" | "body" = "params",
-) {
+export function isOperatingOnSelf(paramName: string, source: 'params' | 'body' = 'params') {
   return (req: Request, res: Response, next: NextFunction) => {
     const authReq = req as AuthenticatedRequest;
-    const targetUserId =
-      source === "params" ? req.params[paramName] : req.body[paramName];
+    const targetUserId = source === 'params' ? req.params[paramName] : req.body[paramName];
     const authenticatedUserId = authReq.auth?.id;
 
     if (targetUserId !== authenticatedUserId) {
-      next(
-        new PermissionError(
-          "You can only perform this action on your own account",
-        ),
-      );
+      next(new PermissionError('You can only perform this action on your own account'));
       return;
     }
 

--- a/server/src/api/validation.test.ts
+++ b/server/src/api/validation.test.ts
@@ -1,6 +1,6 @@
-import { assert } from "chai";
-import { Request, Response } from "express";
-import { ValidationError } from "../utils/errors";
+import { assert } from 'chai';
+import { Request, Response } from 'express';
+import { ValidationError } from '../utils/errors';
 import {
   checkQueryFor,
   checkBodyFor,
@@ -18,7 +18,7 @@ import {
   checkBodyEnum,
   checkQueryEnum,
   oneOf,
-} from "./validation";
+} from './validation';
 
 function mockReq(overrides: Partial<Request> = {}): Request {
   return {
@@ -33,61 +33,61 @@ function mockRes(): Response {
   return {} as Response;
 }
 
-describe("Validation Middleware", function () {
-  describe("checkQueryFor", function () {
-    it("should pass when all required query params are present", function (done) {
-      const middleware = checkQueryFor(["page", "limit"]);
-      const req = mockReq({ query: { page: "1", limit: "10" } as never });
+describe('Validation Middleware', function () {
+  describe('checkQueryFor', function () {
+    it('should pass when all required query params are present', function (done) {
+      const middleware = checkQueryFor(['page', 'limit']);
+      const req = mockReq({ query: { page: '1', limit: '10' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when required query params are missing", function (done) {
-      const middleware = checkQueryFor(["page", "limit"]);
-      const req = mockReq({ query: { page: "1" } as never });
+    it('should fail when required query params are missing', function (done) {
+      const middleware = checkQueryFor(['page', 'limit']);
+      const req = mockReq({ query: { page: '1' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "limit");
+        assert.include((err as Error).message, 'limit');
         done();
       });
     });
   });
 
-  describe("checkBodyFor", function () {
-    it("should pass when all required body fields are present", function (done) {
-      const middleware = checkBodyFor(["name", "email"]);
-      const req = mockReq({ body: { name: "Test", email: "a@b.com" } });
+  describe('checkBodyFor', function () {
+    it('should pass when all required body fields are present', function (done) {
+      const middleware = checkBodyFor(['name', 'email']);
+      const req = mockReq({ body: { name: 'Test', email: 'a@b.com' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when required body fields are missing", function (done) {
-      const middleware = checkBodyFor(["name", "email"]);
-      const req = mockReq({ body: { name: "Test" } });
+    it('should fail when required body fields are missing', function (done) {
+      const middleware = checkBodyFor(['name', 'email']);
+      const req = mockReq({ body: { name: 'Test' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "email");
+        assert.include((err as Error).message, 'email');
         done();
       });
     });
   });
 
-  describe("checkBodyForAtLeastOneOf", function () {
-    it("should pass when at least one field is present", function (done) {
-      const middleware = checkBodyForAtLeastOneOf(["name", "email"]);
-      const req = mockReq({ body: { name: "Test" } });
+  describe('checkBodyForAtLeastOneOf', function () {
+    it('should pass when at least one field is present', function (done) {
+      const middleware = checkBodyForAtLeastOneOf(['name', 'email']);
+      const req = mockReq({ body: { name: 'Test' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when no fields are present", function (done) {
-      const middleware = checkBodyForAtLeastOneOf(["name", "email"]);
+    it('should fail when no fields are present', function (done) {
+      const middleware = checkBodyForAtLeastOneOf(['name', 'email']);
       const req = mockReq({ body: {} });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
@@ -96,18 +96,18 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("checkQueryForAtLeastOneOf", function () {
-    it("should pass when at least one query param is present", function (done) {
-      const middleware = checkQueryForAtLeastOneOf(["search", "filter"]);
-      const req = mockReq({ query: { search: "test" } as never });
+  describe('checkQueryForAtLeastOneOf', function () {
+    it('should pass when at least one query param is present', function (done) {
+      const middleware = checkQueryForAtLeastOneOf(['search', 'filter']);
+      const req = mockReq({ query: { search: 'test' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when no query params are present", function (done) {
-      const middleware = checkQueryForAtLeastOneOf(["search", "filter"]);
+    it('should fail when no query params are present', function (done) {
+      const middleware = checkQueryForAtLeastOneOf(['search', 'filter']);
       const req = mockReq({ query: {} as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
@@ -116,25 +116,19 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("checkBodyForAtLeastOneSet", function () {
-    it("should pass when one complete set is present", function (done) {
-      const middleware = checkBodyForAtLeastOneSet(
-        ["email", "password"],
-        ["token"],
-      );
-      const req = mockReq({ body: { token: "abc" } });
+  describe('checkBodyForAtLeastOneSet', function () {
+    it('should pass when one complete set is present', function (done) {
+      const middleware = checkBodyForAtLeastOneSet(['email', 'password'], ['token']);
+      const req = mockReq({ body: { token: 'abc' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when no complete set is present", function (done) {
-      const middleware = checkBodyForAtLeastOneSet(
-        ["email", "password"],
-        ["token"],
-      );
-      const req = mockReq({ body: { email: "test@test.com" } });
+    it('should fail when no complete set is present', function (done) {
+      const middleware = checkBodyForAtLeastOneSet(['email', 'password'], ['token']);
+      const req = mockReq({ body: { email: 'test@test.com' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
         done();
@@ -142,53 +136,53 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("checkBodyForNoExtraFields", function () {
-    it("should pass when no extra fields are present", function (done) {
-      const middleware = checkBodyForNoExtraFields(["name", "email"]);
-      const req = mockReq({ body: { name: "Test" } });
+  describe('checkBodyForNoExtraFields', function () {
+    it('should pass when no extra fields are present', function (done) {
+      const middleware = checkBodyForNoExtraFields(['name', 'email']);
+      const req = mockReq({ body: { name: 'Test' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when extra fields are present", function (done) {
-      const middleware = checkBodyForNoExtraFields(["name", "email"]);
-      const req = mockReq({ body: { name: "Test", hack: "true" } });
+    it('should fail when extra fields are present', function (done) {
+      const middleware = checkBodyForNoExtraFields(['name', 'email']);
+      const req = mockReq({ body: { name: 'Test', hack: 'true' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "hack");
+        assert.include((err as Error).message, 'hack');
         done();
       });
     });
   });
 
-  describe("checkQueryForNoExtraFields", function () {
-    it("should pass when no extra query fields are present", function (done) {
-      const middleware = checkQueryForNoExtraFields(["page", "limit"]);
-      const req = mockReq({ query: { page: "1" } as never });
+  describe('checkQueryForNoExtraFields', function () {
+    it('should pass when no extra query fields are present', function (done) {
+      const middleware = checkQueryForNoExtraFields(['page', 'limit']);
+      const req = mockReq({ query: { page: '1' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail when extra query fields are present", function (done) {
-      const middleware = checkQueryForNoExtraFields(["page", "limit"]);
-      const req = mockReq({ query: { page: "1", extra: "bad" } as never });
+    it('should fail when extra query fields are present', function (done) {
+      const middleware = checkQueryForNoExtraFields(['page', 'limit']);
+      const req = mockReq({ query: { page: '1', extra: 'bad' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "extra");
+        assert.include((err as Error).message, 'extra');
         done();
       });
     });
   });
 
-  describe("validateUUIDsInParams", function () {
-    it("should pass for valid UUIDs", function (done) {
-      const middleware = validateUUIDsInParams(["id"]);
+  describe('validateUUIDsInParams', function () {
+    it('should pass for valid UUIDs', function (done) {
+      const middleware = validateUUIDsInParams(['id']);
       const req = mockReq({
-        params: { id: "550e8400-e29b-41d4-a716-446655440000" },
+        params: { id: '550e8400-e29b-41d4-a716-446655440000' },
       });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -196,18 +190,18 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for invalid UUIDs", function (done) {
-      const middleware = validateUUIDsInParams(["id"]);
-      const req = mockReq({ params: { id: "not-a-uuid" } });
+    it('should fail for invalid UUIDs', function (done) {
+      const middleware = validateUUIDsInParams(['id']);
+      const req = mockReq({ params: { id: 'not-a-uuid' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "id");
+        assert.include((err as Error).message, 'id');
         done();
       });
     });
 
-    it("should skip missing params", function (done) {
-      const middleware = validateUUIDsInParams(["id"]);
+    it('should skip missing params', function (done) {
+      const middleware = validateUUIDsInParams(['id']);
       const req = mockReq({ params: {} });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -216,11 +210,11 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("validateUUIDsInQuery", function () {
-    it("should pass for valid UUIDs in query", function (done) {
-      const middleware = validateUUIDsInQuery(["userId"]);
+  describe('validateUUIDsInQuery', function () {
+    it('should pass for valid UUIDs in query', function (done) {
+      const middleware = validateUUIDsInQuery(['userId']);
       const req = mockReq({
-        query: { userId: "550e8400-e29b-41d4-a716-446655440000" } as never,
+        query: { userId: '550e8400-e29b-41d4-a716-446655440000' } as never,
       });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -228,9 +222,9 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for invalid UUIDs in query", function (done) {
-      const middleware = validateUUIDsInQuery(["userId"]);
-      const req = mockReq({ query: { userId: "invalid" } as never });
+    it('should fail for invalid UUIDs in query', function (done) {
+      const middleware = validateUUIDsInQuery(['userId']);
+      const req = mockReq({ query: { userId: 'invalid' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
         done();
@@ -238,11 +232,11 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("validateUUIDsInBody", function () {
-    it("should pass for valid UUIDs in body", function (done) {
-      const middleware = validateUUIDsInBody(["userId"]);
+  describe('validateUUIDsInBody', function () {
+    it('should pass for valid UUIDs in body', function (done) {
+      const middleware = validateUUIDsInBody(['userId']);
       const req = mockReq({
-        body: { userId: "550e8400-e29b-41d4-a716-446655440000" },
+        body: { userId: '550e8400-e29b-41d4-a716-446655440000' },
       });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -250,9 +244,9 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for invalid UUIDs in body", function (done) {
-      const middleware = validateUUIDsInBody(["userId"]);
-      const req = mockReq({ body: { userId: "invalid" } });
+    it('should fail for invalid UUIDs in body', function (done) {
+      const middleware = validateUUIDsInBody(['userId']);
+      const req = mockReq({ body: { userId: 'invalid' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
         done();
@@ -260,11 +254,11 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("convertQueryParamToDate", function () {
-    it("should convert valid date strings", function (done) {
-      const middleware = convertQueryParamToDate(["startDate"]);
+  describe('convertQueryParamToDate', function () {
+    it('should convert valid date strings', function (done) {
+      const middleware = convertQueryParamToDate(['startDate']);
       const req = mockReq({
-        query: { startDate: "2024-01-15" } as never,
+        query: { startDate: '2024-01-15' } as never,
       });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -273,20 +267,20 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for invalid date strings", function (done) {
-      const middleware = convertQueryParamToDate(["startDate"]);
+    it('should fail for invalid date strings', function (done) {
+      const middleware = convertQueryParamToDate(['startDate']);
       const req = mockReq({
-        query: { startDate: "not-a-date" } as never,
+        query: { startDate: 'not-a-date' } as never,
       });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "startDate");
+        assert.include((err as Error).message, 'startDate');
         done();
       });
     });
 
-    it("should skip missing params", function (done) {
-      const middleware = convertQueryParamToDate(["startDate"]);
+    it('should skip missing params', function (done) {
+      const middleware = convertQueryParamToDate(['startDate']);
       const req = mockReq({ query: {} as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
@@ -295,10 +289,10 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("convertBodyParamToDate", function () {
-    it("should convert valid date strings in body", function (done) {
-      const middleware = convertBodyParamToDate(["dueDate"]);
-      const req = mockReq({ body: { dueDate: "2024-06-01" } });
+  describe('convertBodyParamToDate', function () {
+    it('should convert valid date strings in body', function (done) {
+      const middleware = convertBodyParamToDate(['dueDate']);
+      const req = mockReq({ body: { dueDate: '2024-06-01' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         assert.instanceOf(req.body.dueDate, Date);
@@ -306,9 +300,9 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for invalid date strings in body", function (done) {
-      const middleware = convertBodyParamToDate(["dueDate"]);
-      const req = mockReq({ body: { dueDate: "nope" } });
+    it('should fail for invalid date strings in body', function (done) {
+      const middleware = convertBodyParamToDate(['dueDate']);
+      const req = mockReq({ body: { dueDate: 'nope' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
         done();
@@ -316,10 +310,10 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("convertQueryParamToNumber", function () {
-    it("should convert valid number strings", function (done) {
-      const middleware = convertQueryParamToNumber(["limit"]);
-      const req = mockReq({ query: { limit: "25" } as never });
+  describe('convertQueryParamToNumber', function () {
+    it('should convert valid number strings', function (done) {
+      const middleware = convertQueryParamToNumber(['limit']);
+      const req = mockReq({ query: { limit: '25' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         assert.equal(req.query.limit as unknown, 25);
@@ -327,50 +321,30 @@ describe("Validation Middleware", function () {
       });
     });
 
-    it("should fail for non-numeric strings", function (done) {
-      const middleware = convertQueryParamToNumber(["limit"]);
-      const req = mockReq({ query: { limit: "abc" } as never });
+    it('should fail for non-numeric strings', function (done) {
+      const middleware = convertQueryParamToNumber(['limit']);
+      const req = mockReq({ query: { limit: 'abc' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
-        assert.include((err as Error).message, "limit");
+        assert.include((err as Error).message, 'limit');
         done();
       });
     });
   });
 
-  describe("checkBodyEnum", function () {
-    it("should pass for valid enum values", function (done) {
-      const middleware = checkBodyEnum("role", ["admin", "user", "guest"]);
-      const req = mockReq({ body: { role: "admin" } });
+  describe('checkBodyEnum', function () {
+    it('should pass for valid enum values', function (done) {
+      const middleware = checkBodyEnum('role', ['admin', 'user', 'guest']);
+      const req = mockReq({ body: { role: 'admin' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail for invalid enum values", function (done) {
-      const middleware = checkBodyEnum("role", ["admin", "user", "guest"]);
-      const req = mockReq({ body: { role: "superadmin" } });
-      middleware(req, mockRes(), (err?: unknown) => {
-        assert.instanceOf(err, ValidationError);
-        done();
-      });
-    });
-  });
-
-  describe("checkQueryEnum", function () {
-    it("should pass for valid enum values in query", function (done) {
-      const middleware = checkQueryEnum("sort", ["asc", "desc"]);
-      const req = mockReq({ query: { sort: "asc" } as never });
-      middleware(req, mockRes(), (err?: unknown) => {
-        assert.isUndefined(err);
-        done();
-      });
-    });
-
-    it("should fail for invalid enum values in query", function (done) {
-      const middleware = checkQueryEnum("sort", ["asc", "desc"]);
-      const req = mockReq({ query: { sort: "random" } as never });
+    it('should fail for invalid enum values', function (done) {
+      const middleware = checkBodyEnum('role', ['admin', 'user', 'guest']);
+      const req = mockReq({ body: { role: 'superadmin' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.instanceOf(err, ValidationError);
         done();
@@ -378,40 +352,51 @@ describe("Validation Middleware", function () {
     });
   });
 
-  describe("oneOf", function () {
-    it("should pass if the first middleware succeeds", function (done) {
-      const middleware = oneOf([
-        checkBodyFor(["name"]),
-        checkBodyFor(["email"]),
-      ]);
-      const req = mockReq({ body: { name: "Test" } });
+  describe('checkQueryEnum', function () {
+    it('should pass for valid enum values in query', function (done) {
+      const middleware = checkQueryEnum('sort', ['asc', 'desc']);
+      const req = mockReq({ query: { sort: 'asc' } as never });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should pass if the second middleware succeeds", function (done) {
-      const middleware = oneOf([
-        checkBodyFor(["name"]),
-        checkBodyFor(["email"]),
-      ]);
-      const req = mockReq({ body: { email: "test@test.com" } });
+    it('should fail for invalid enum values in query', function (done) {
+      const middleware = checkQueryEnum('sort', ['asc', 'desc']);
+      const req = mockReq({ query: { sort: 'random' } as never });
+      middleware(req, mockRes(), (err?: unknown) => {
+        assert.instanceOf(err, ValidationError);
+        done();
+      });
+    });
+  });
+
+  describe('oneOf', function () {
+    it('should pass if the first middleware succeeds', function (done) {
+      const middleware = oneOf([checkBodyFor(['name']), checkBodyFor(['email'])]);
+      const req = mockReq({ body: { name: 'Test' } });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isUndefined(err);
         done();
       });
     });
 
-    it("should fail if all middlewares fail", function (done) {
-      const middleware = oneOf([
-        checkBodyFor(["name"]),
-        checkBodyFor(["email"]),
-      ]);
+    it('should pass if the second middleware succeeds', function (done) {
+      const middleware = oneOf([checkBodyFor(['name']), checkBodyFor(['email'])]);
+      const req = mockReq({ body: { email: 'test@test.com' } });
+      middleware(req, mockRes(), (err?: unknown) => {
+        assert.isUndefined(err);
+        done();
+      });
+    });
+
+    it('should fail if all middlewares fail', function (done) {
+      const middleware = oneOf([checkBodyFor(['name']), checkBodyFor(['email'])]);
       const req = mockReq({ body: {} });
       middleware(req, mockRes(), (err?: unknown) => {
         assert.isOk(err);
-        assert.include((err as Error).message, "OR");
+        assert.include((err as Error).message, 'OR');
         done();
       });
     });

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -1,28 +1,25 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
-import { ErrorMessages, ValidationError } from "../utils/errors";
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { ErrorMessages, ValidationError } from '../utils/errors';
 
-type RequestProperty = "query" | "body";
+type RequestProperty = 'query' | 'body';
 
 export function checkQueryFor(strArray: string[]) {
-  return checkFor("query", strArray);
+  return checkFor('query', strArray);
 }
 
 export function checkBodyFor(strArray: string[]) {
-  return checkFor("body", strArray);
+  return checkFor('body', strArray);
 }
 
 function checkFor(name: RequestProperty, strArray: string[]): RequestHandler {
   return (req, res, next) => {
     const obj = req[name] as Record<string, unknown>;
-    const missing = strArray.filter(
-      (str) => !Object.prototype.hasOwnProperty.call(obj, str),
-    );
+    const missing = strArray.filter((str) => !Object.prototype.hasOwnProperty.call(obj, str));
     if (missing.length > 0) {
       return next(
-        new ValidationError(
-          `${capitalize(name)} parameter(s) missing: ${missing.join(", ")}`,
-          { missing },
-        ),
+        new ValidationError(`${capitalize(name)} parameter(s) missing: ${missing.join(', ')}`, {
+          missing,
+        }),
       );
     }
     return next();
@@ -31,13 +28,11 @@ function checkFor(name: RequestProperty, strArray: string[]): RequestHandler {
 
 export function checkBodyForAtLeastOneOf(strArray: string[]): RequestHandler {
   return (req, res, next) => {
-    const existing = strArray.filter((str) =>
-      Object.prototype.hasOwnProperty.call(req.body, str),
-    );
+    const existing = strArray.filter((str) => Object.prototype.hasOwnProperty.call(req.body, str));
     if (!existing.length) {
       return next(
         new ValidationError(
-          `Body must include at least one of the following: ${strArray.join(", ")}`,
+          `Body must include at least one of the following: ${strArray.join(', ')}`,
           { existing },
         ),
       );
@@ -48,13 +43,11 @@ export function checkBodyForAtLeastOneOf(strArray: string[]): RequestHandler {
 
 export function checkQueryForAtLeastOneOf(strArray: string[]): RequestHandler {
   return (req, res, next) => {
-    const existing = strArray.filter((str) =>
-      Object.prototype.hasOwnProperty.call(req.query, str),
-    );
+    const existing = strArray.filter((str) => Object.prototype.hasOwnProperty.call(req.query, str));
     if (!existing.length) {
       return next(
         new ValidationError(
-          `Query must include at least one of the following: ${strArray.join(", ")}`,
+          `Query must include at least one of the following: ${strArray.join(', ')}`,
           { existing },
         ),
       );
@@ -63,9 +56,7 @@ export function checkQueryForAtLeastOneOf(strArray: string[]): RequestHandler {
   };
 }
 
-export function checkBodyForAtLeastOneSet(
-  ...strArrays: string[][]
-): RequestHandler {
+export function checkBodyForAtLeastOneSet(...strArrays: string[][]): RequestHandler {
   return (req, res, next) => {
     const missings = strArrays.map((arr) =>
       arr.filter((str) => !Object.prototype.hasOwnProperty.call(req.body, str)),
@@ -75,7 +66,7 @@ export function checkBodyForAtLeastOneSet(
     if (allMissing.length === strArrays.length) {
       return next(
         new ValidationError(
-          `Body parameter(s) missing. This requires a combination like the following: ${strArrays.map((a) => a.join(", ")).join(" | ")}`,
+          `Body parameter(s) missing. This requires a combination like the following: ${strArrays.map((a) => a.join(', ')).join(' | ')}`,
           { details: strArrays },
         ),
       );
@@ -84,9 +75,7 @@ export function checkBodyForAtLeastOneSet(
   };
 }
 
-export function checkBodyForNoExtraFields(
-  allowedFields: string[],
-): RequestHandler {
+export function checkBodyForNoExtraFields(allowedFields: string[]): RequestHandler {
   return (req, res, next) => {
     const extraFields: string[] = [];
     for (const key of Object.keys(req.body)) {
@@ -97,7 +86,7 @@ export function checkBodyForNoExtraFields(
     if (extraFields.length > 0) {
       return next(
         new ValidationError(
-          `Body cannot include the parameters: ${extraFields.join(", ")}. This endpoint accepts the values: ${allowedFields.join(", ")}`,
+          `Body cannot include the parameters: ${extraFields.join(', ')}. This endpoint accepts the values: ${allowedFields.join(', ')}`,
           { extraFields },
         ),
       );
@@ -106,9 +95,7 @@ export function checkBodyForNoExtraFields(
   };
 }
 
-export function checkQueryForNoExtraFields(
-  allowedFields: string[],
-): RequestHandler {
+export function checkQueryForNoExtraFields(allowedFields: string[]): RequestHandler {
   return (req, res, next) => {
     const extraFields: string[] = [];
     for (const key of Object.keys(req.query)) {
@@ -119,7 +106,7 @@ export function checkQueryForNoExtraFields(
     if (extraFields.length > 0) {
       return next(
         new ValidationError(
-          `Query cannot include the parameters: ${extraFields.join(", ")}. This endpoint accepts the values: ${allowedFields.join(", ")}`,
+          `Query cannot include the parameters: ${extraFields.join(', ')}. This endpoint accepts the values: ${allowedFields.join(', ')}`,
           { extraFields },
         ),
       );
@@ -128,17 +115,14 @@ export function checkQueryForNoExtraFields(
   };
 }
 
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function validateUUIDsInParams(paramArray: string[]): RequestHandler {
   return (req, res, next) => {
     for (const paramName of paramArray) {
       const paramValue = req.params[paramName] as string;
       if (paramValue && !UUID_REGEX.test(paramValue)) {
-        return next(
-          new ValidationError(ErrorMessages.invalidUuidFormat(paramName)),
-        );
+        return next(new ValidationError(ErrorMessages.invalidUuidFormat(paramName)));
       }
     }
     return next();
@@ -150,9 +134,7 @@ export function validateUUIDsInQuery(queryArray: string[]): RequestHandler {
     for (const queryName of queryArray) {
       const queryValue = req.query[queryName] as string;
       if (queryValue && !UUID_REGEX.test(queryValue)) {
-        return next(
-          new ValidationError(ErrorMessages.invalidUuidFormat(queryName)),
-        );
+        return next(new ValidationError(ErrorMessages.invalidUuidFormat(queryName)));
       }
     }
     return next();
@@ -164,9 +146,7 @@ export function validateUUIDsInBody(bodyArray: string[]): RequestHandler {
     for (const bodyName of bodyArray) {
       const bodyValue = req.body[bodyName];
       if (bodyValue && !UUID_REGEX.test(bodyValue)) {
-        return next(
-          new ValidationError(ErrorMessages.invalidUuidFormat(bodyName)),
-        );
+        return next(new ValidationError(ErrorMessages.invalidUuidFormat(bodyName)));
       }
     }
     return next();
@@ -179,9 +159,7 @@ export function convertQueryParamToDate(dateParams: string[]): RequestHandler {
       if (req.query[param] !== undefined && req.query[param] !== null) {
         const parsedDate = new Date(req.query[param] as string);
         if (isNaN(parsedDate.getTime())) {
-          return next(
-            new ValidationError(`Invalid Value: ${param} must be a valid date`),
-          );
+          return next(new ValidationError(`Invalid Value: ${param} must be a valid date`));
         }
         (req.query as Record<string, unknown>)[param] = parsedDate;
       }
@@ -196,9 +174,7 @@ export function convertBodyParamToDate(dateParams: string[]): RequestHandler {
       if (req.body[param] !== undefined && req.body[param] !== null) {
         const parsedDate = new Date(req.body[param] as string);
         if (isNaN(parsedDate.getTime())) {
-          return next(
-            new ValidationError(`Invalid Value: ${param} must be a valid date`),
-          );
+          return next(new ValidationError(`Invalid Value: ${param} must be a valid date`));
         }
         req.body[param] = parsedDate;
       }
@@ -207,19 +183,13 @@ export function convertBodyParamToDate(dateParams: string[]): RequestHandler {
   };
 }
 
-export function convertQueryParamToNumber(
-  numberParams: string[],
-): RequestHandler {
+export function convertQueryParamToNumber(numberParams: string[]): RequestHandler {
   return (req, res, next) => {
     for (const param of numberParams) {
       if (req.query[param] !== undefined && req.query[param] !== null) {
         const parsedNumber = Number(req.query[param]);
         if (isNaN(parsedNumber)) {
-          return next(
-            new ValidationError(
-              `Invalid Value: ${param} must be a valid number`,
-            ),
-          );
+          return next(new ValidationError(`Invalid Value: ${param} must be a valid number`));
         }
         (req.query as Record<string, unknown>)[param] = parsedNumber;
       }
@@ -228,18 +198,12 @@ export function convertQueryParamToNumber(
   };
 }
 
-export function checkBodyEnum(
-  field: string,
-  allowedValues: readonly string[],
-): RequestHandler {
-  return checkEnum("body", field, allowedValues);
+export function checkBodyEnum(field: string, allowedValues: readonly string[]): RequestHandler {
+  return checkEnum('body', field, allowedValues);
 }
 
-export function checkQueryEnum(
-  field: string,
-  allowedValues: readonly string[],
-): RequestHandler {
-  return checkEnum("query", field, allowedValues);
+export function checkQueryEnum(field: string, allowedValues: readonly string[]): RequestHandler {
+  return checkEnum('query', field, allowedValues);
 }
 
 function checkEnum(
@@ -250,11 +214,7 @@ function checkEnum(
   return (req, res, next) => {
     const value = (req[objName] as Record<string, unknown>)[field];
     if (!value || !allowedValues.includes(value as string)) {
-      return next(
-        new ValidationError(
-          ErrorMessages.invalidBodyField(field, [...allowedValues]),
-        ),
-      );
+      return next(new ValidationError(ErrorMessages.invalidBodyField(field, [...allowedValues])));
     }
     return next();
   };
@@ -269,11 +229,11 @@ export function oneOf(
     const tryNextMiddleware = (index: number) => {
       if (index >= middlewares.length) {
         if (errors.length === 0) {
-          next(new ValidationError("None of the validation options passed"));
+          next(new ValidationError('None of the validation options passed'));
         } else if (errors.length === 1) {
           next(errors[0]);
         } else {
-          const combinedMessage = errors.map((err) => err.message).join(" OR ");
+          const combinedMessage = errors.map((err) => err.message).join(' OR ');
           const firstError = errors[0];
           firstError.message = combinedMessage;
           next(firstError);

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -1,9 +1,9 @@
-import { optionalEnvVars, requiredEnvVars } from "./envVars";
+import { optionalEnvVars, requiredEnvVars } from './envVars';
 
 export enum Environments {
-  PRODUCTION = "production",
-  DEVELOPMENT = "development",
-  TEST = "test",
+  PRODUCTION = 'production',
+  DEVELOPMENT = 'development',
+  TEST = 'test',
 }
 
 type EnvVars = {
@@ -39,11 +39,11 @@ export class Config implements Partial<EnvVars> {
   get BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return "https://your-production-client-url.com";
+        return 'https://your-production-client-url.com';
       case Environments.DEVELOPMENT:
-        return "http://localhost:10020";
+        return 'http://localhost:10020';
       case Environments.TEST:
-        return "http://localhost:10021";
+        return 'http://localhost:10021';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -52,11 +52,11 @@ export class Config implements Partial<EnvVars> {
   get CLIENT_BASE_URL(): string {
     switch (this.env) {
       case Environments.PRODUCTION:
-        return "https://your-production-server-url.com";
+        return 'https://your-production-server-url.com';
       case Environments.DEVELOPMENT:
-        return "http://localhost:3000";
+        return 'http://localhost:3000';
       case Environments.TEST:
-        return "http://localhost:3001";
+        return 'http://localhost:3001';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }
@@ -66,9 +66,9 @@ export class Config implements Partial<EnvVars> {
     switch (this.env) {
       case Environments.DEVELOPMENT:
       case Environments.TEST:
-        return "http://localhost:10020/v1/auth/google/web/authorize";
+        return 'http://localhost:10020/v1/auth/google/web/authorize';
       case Environments.PRODUCTION: // google does not allow testing from localhost!
-        return "https://your-production-url/v1/auth/google/web/authorize";
+        return 'https://your-production-url/v1/auth/google/web/authorize';
       default:
         throw new Error(`Unknown environment: ${this.env}`);
     }

--- a/server/src/config/envVars.ts
+++ b/server/src/config/envVars.ts
@@ -1,16 +1,11 @@
-export const requiredEnvVars = [
-  "NODE_ENV",
-  "PORT",
-  "DATABASE_URL",
-  "JWT_SECRET",
-] as const;
+export const requiredEnvVars = ['NODE_ENV', 'PORT', 'DATABASE_URL', 'JWT_SECRET'] as const;
 
 export const optionalEnvVars = [
-  "SOME_OPTIONAL_ENV_VARIABLE",
-  "BASIC_AUTH_TOKENS",
-  "REDIS_URL",
-  "GOOGLE_CLIENT_ID",
-  "GOOGLE_CLIENT_SECRET",
+  'SOME_OPTIONAL_ENV_VARIABLE',
+  'BASIC_AUTH_TOKENS',
+  'REDIS_URL',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
 ] as const;
 
 export type RequiredEnvVar = (typeof requiredEnvVars)[number];

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,4 +1,4 @@
-import config from "./config";
-export * from "./config";
+import config from './config';
+export * from './config';
 
 export default config;

--- a/server/src/db/config.ts
+++ b/server/src/db/config.ts
@@ -23,20 +23,20 @@ interface DBConfigMap {
 const config: DBConfigMap = {
   development: {
     url: process.env.DATABASE_URL as string,
-    dialect: "postgres",
+    dialect: 'postgres',
     // the database name must be provided for sequelize-cli,
     // even though it is included in the url
-    database: (process.env.DATABASE_URL as string).split("/").slice(-1)[0],
+    database: (process.env.DATABASE_URL as string).split('/').slice(-1)[0],
   },
   test: {
     url: process.env.DATABASE_URL as string,
-    dialect: "postgres",
+    dialect: 'postgres',
     logging: false,
-    database: (process.env.DATABASE_URL as string).split("/").slice(-1)[0],
+    database: (process.env.DATABASE_URL as string).split('/').slice(-1)[0],
   },
   production: {
     url: `${process.env.DATABASE_URL}`,
-    dialect: "postgres",
+    dialect: 'postgres',
     ssl: true,
     dialectOptions: {
       ssl: {
@@ -44,7 +44,7 @@ const config: DBConfigMap = {
         rejectUnauthorized: false, //https://github.com/brianc/node-postgres/issues/2009#issuecomment-556020509
       },
     },
-    database: (process.env.DATABASE_URL as string).split("/").slice(-1)[0],
+    database: (process.env.DATABASE_URL as string).split('/').slice(-1)[0],
   },
 };
 

--- a/server/src/db/migrations/20250428211324-create-user.js
+++ b/server/src/db/migrations/20250428211324-create-user.js
@@ -1,9 +1,9 @@
-"use strict";
+'use strict';
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable("users", {
+    await queryInterface.createTable('users', {
       id: {
         type: Sequelize.UUID,
         primaryKey: true,
@@ -23,9 +23,9 @@ module.exports = {
         type: Sequelize.STRING,
       },
       role: {
-        type: Sequelize.ENUM("admin", "user", "guest"),
+        type: Sequelize.ENUM('admin', 'user', 'guest'),
         allowNull: false,
-        defaultValue: "user",
+        defaultValue: 'user',
       },
       createdAt: {
         allowNull: false,
@@ -39,6 +39,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable("users");
+    await queryInterface.dropTable('users');
   },
 };

--- a/server/src/db/migrations/20250429000000-add-user-fields.js
+++ b/server/src/db/migrations/20250429000000-add-user-fields.js
@@ -1,28 +1,28 @@
-"use strict";
+'use strict';
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn("users", "firstName", {
+    await queryInterface.addColumn('users', 'firstName', {
       type: Sequelize.STRING,
       allowNull: false,
-      defaultValue: "",
+      defaultValue: '',
     });
-    await queryInterface.addColumn("users", "lastName", {
+    await queryInterface.addColumn('users', 'lastName', {
       type: Sequelize.STRING,
     });
-    await queryInterface.addColumn("users", "verifiedEmail", {
+    await queryInterface.addColumn('users', 'verifiedEmail', {
       type: Sequelize.STRING,
     });
-    await queryInterface.addColumn("users", "passwordHash", {
+    await queryInterface.addColumn('users', 'passwordHash', {
       type: Sequelize.STRING,
     });
   },
 
   async down(queryInterface) {
-    await queryInterface.removeColumn("users", "firstName");
-    await queryInterface.removeColumn("users", "lastName");
-    await queryInterface.removeColumn("users", "verifiedEmail");
-    await queryInterface.removeColumn("users", "passwordHash");
+    await queryInterface.removeColumn('users', 'firstName');
+    await queryInterface.removeColumn('users', 'lastName');
+    await queryInterface.removeColumn('users', 'verifiedEmail');
+    await queryInterface.removeColumn('users', 'passwordHash');
   },
 };

--- a/server/src/db/models/user.model/index.ts
+++ b/server/src/db/models/user.model/index.ts
@@ -1,2 +1,2 @@
-import User from "./user.model";
+import User from './user.model';
 export default User;

--- a/server/src/db/models/user.model/user.model.ts
+++ b/server/src/db/models/user.model/user.model.ts
@@ -4,8 +4,8 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
-} from "sequelize";
-import sequelize from "../../sequelize";
+} from 'sequelize';
+import sequelize from '../../sequelize';
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare id: CreationOptional<string>;
@@ -16,7 +16,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare verifiedEmail: CreationOptional<string>;
   declare passwordHash: CreationOptional<string>;
   declare profileImageUrl: CreationOptional<string>;
-  declare role: CreationOptional<"admin" | "user" | "guest">;
+  declare role: CreationOptional<'admin' | 'user' | 'guest'>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -57,16 +57,16 @@ User.init(
     passwordHash: DataTypes.STRING,
     profileImageUrl: DataTypes.STRING,
     role: {
-      type: DataTypes.ENUM("admin", "user", "guest"),
+      type: DataTypes.ENUM('admin', 'user', 'guest'),
       allowNull: false,
-      defaultValue: "user",
+      defaultValue: 'user',
     },
     createdAt: DataTypes.DATE,
     updatedAt: DataTypes.DATE,
   },
   {
     sequelize,
-    modelName: "user",
+    modelName: 'user',
   },
 );
 

--- a/server/src/db/sequelize.ts
+++ b/server/src/db/sequelize.ts
@@ -1,16 +1,14 @@
-import { Sequelize } from "sequelize";
-import config from "../config";
-import DBConfig from "./config";
+import { Sequelize } from 'sequelize';
+import config from '../config';
+import DBConfig from './config';
 
 if (!config.NODE_ENV) {
-  throw new Error("NODE_ENV is not defined");
+  throw new Error('NODE_ENV is not defined');
 }
 
 const dbConfigForThisEnv = DBConfig[config.NODE_ENV];
 if (!dbConfigForThisEnv) {
-  throw new Error(
-    `No database configuration found for environment: ${config.NODE_ENV}`,
-  );
+  throw new Error(`No database configuration found for environment: ${config.NODE_ENV}`);
 }
 
 // Extract the URL and remove it from the options to avoid duplicate URL in constructor
@@ -19,7 +17,7 @@ const { url, ...otherOptions } = dbConfigForThisEnv;
 // Create sequelize instance with proper typing
 const sequelize = new Sequelize(url, {
   ...otherOptions,
-  dialect: "postgres", // Add explicit dialect since it's required by the type
+  dialect: 'postgres', // Add explicit dialect since it's required by the type
 });
 
 // For ES Module import

--- a/server/src/docs/index.ts
+++ b/server/src/docs/index.ts
@@ -1,41 +1,41 @@
-import { Application } from "express";
-import fs from "fs";
-import path from "path";
-import redocExpress from "redoc-express";
-import swaggerJsdoc from "swagger-jsdoc";
+import { Application } from 'express';
+import fs from 'fs';
+import path from 'path';
+import redocExpress from 'redoc-express';
+import swaggerJsdoc from 'swagger-jsdoc';
 
-let apiGuideMarkdownDescription = "";
+let apiGuideMarkdownDescription = '';
 try {
-  const apiGuidePath = path.join(__dirname, "API_GUIDE.md");
-  apiGuideMarkdownDescription = fs.readFileSync(apiGuidePath, "utf8");
+  const apiGuidePath = path.join(__dirname, 'API_GUIDE.md');
+  apiGuideMarkdownDescription = fs.readFileSync(apiGuidePath, 'utf8');
 } catch {
-  apiGuideMarkdownDescription = "";
+  apiGuideMarkdownDescription = '';
 }
 
 const options: swaggerJsdoc.Options = {
   definition: {
-    openapi: "3.0.0",
+    openapi: '3.0.0',
     info: {
-      title: "API Documentation",
-      version: "1.0.0",
+      title: 'API Documentation',
+      version: '1.0.0',
       description: apiGuideMarkdownDescription,
       contact: {
-        name: "API Support",
-        email: "support@example.com",
+        name: 'API Support',
+        email: 'support@example.com',
       },
     },
     servers: [
       {
-        url: "http://localhost:10020",
-        description: "Development server",
+        url: 'http://localhost:10020',
+        description: 'Development server',
       },
     ],
     components: {
       securitySchemes: {
         bearerAuth: {
-          type: "http",
-          scheme: "bearer",
-          bearerFormat: "JWT",
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
         },
       },
     },
@@ -47,43 +47,43 @@ const options: swaggerJsdoc.Options = {
   },
   apis: [
     // API documentation YAML files
-    path.join(__dirname, "../api/**/*.api.docs.yaml"),
+    path.join(__dirname, '../api/**/*.api.docs.yaml'),
     // Additional schema files from docs folder
-    path.join(__dirname, "./**/*.yaml"),
+    path.join(__dirname, './**/*.yaml'),
   ],
 };
 
 const swaggerSpec = swaggerJsdoc(options);
 
 function addDocRoutes(app: Application) {
-  app.get("/api-docs", (req, res) => {
+  app.get('/api-docs', (req, res) => {
     res.json(swaggerSpec);
   });
 
   // ReDoc routes
   app.use(
-    "/docs",
+    '/docs',
     redocExpress({
-      title: "API Documentation",
-      specUrl: "/swagger.json",
+      title: 'API Documentation',
+      specUrl: '/swagger.json',
       redocOptions: {
         theme: {
           colors: {
             primary: {
-              main: "#1976d2", // Match primary color from client
+              main: '#1976d2', // Match primary color from client
             },
           },
         },
         logo: {
-          gutter: "20px", // Add some spacing around the logo
+          gutter: '20px', // Add some spacing around the logo
         },
       },
     }),
   );
 
   // Serve the raw JSON spec for debugging and for ReDoc to consume
-  app.get("/swagger.json", (req, res) => {
-    res.setHeader("Content-Type", "application/json");
+  app.get('/swagger.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
     res.send(swaggerSpec);
   });
 }

--- a/server/src/lib/auth/auth.lib.ts
+++ b/server/src/lib/auth/auth.lib.ts
@@ -1,13 +1,9 @@
-import * as bcrypt from "bcrypt";
-import { OAuth2Client } from "google-auth-library";
-import config from "../../config/config";
-import User from "../../db/models/user.model";
-import {
-  AuthenticationError,
-  ConflictError,
-  ValidationError,
-} from "../../utils/errors";
-import { generateToken } from "../../utils/jwt";
+import * as bcrypt from 'bcrypt';
+import { OAuth2Client } from 'google-auth-library';
+import config from '../../config/config';
+import User from '../../db/models/user.model';
+import { AuthenticationError, ConflictError, ValidationError } from '../../utils/errors';
+import { generateToken } from '../../utils/jwt';
 
 const SALT_ROUNDS = 10;
 
@@ -24,14 +20,14 @@ export async function signup({
 }): Promise<{ user: User; token: string }> {
   const existing = await User.findOne({ where: { email } });
   if (existing) {
-    throw new ConflictError("A user with this email already exists");
+    throw new ConflictError('A user with this email already exists');
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
   const user = await User.create({
     email,
     firstName,
-    lastName: lastName ?? "",
+    lastName: lastName ?? '',
     passwordHash,
   });
 
@@ -48,12 +44,12 @@ export async function login({
 }): Promise<{ user: User; token: string }> {
   const user = await User.findOne({ where: { email } });
   if (!user || !user.passwordHash) {
-    throw new AuthenticationError("Invalid email or password");
+    throw new AuthenticationError('Invalid email or password');
   }
 
   const valid = await bcrypt.compare(password, user.passwordHash);
   if (!valid) {
-    throw new AuthenticationError("Invalid email or password");
+    throw new AuthenticationError('Invalid email or password');
   }
 
   const token = await generateToken(user);
@@ -66,7 +62,7 @@ export async function googleSignIn({
   idToken: string;
 }): Promise<{ user: User; token: string }> {
   if (!config.GOOGLE_CLIENT_ID) {
-    throw new ValidationError("Google sign-in is not configured");
+    throw new ValidationError('Google sign-in is not configured');
   }
 
   const client = new OAuth2Client(config.GOOGLE_CLIENT_ID);
@@ -78,11 +74,11 @@ export async function googleSignIn({
     });
     payload = ticket.getPayload();
   } catch {
-    throw new AuthenticationError("Invalid Google ID token");
+    throw new AuthenticationError('Invalid Google ID token');
   }
 
   if (!payload || !payload.email) {
-    throw new AuthenticationError("Invalid Google ID token");
+    throw new AuthenticationError('Invalid Google ID token');
   }
 
   let user = await User.findOne({ where: { email: payload.email } });
@@ -94,8 +90,8 @@ export async function googleSignIn({
   } else {
     user = await User.create({
       email: payload.email,
-      firstName: payload.given_name ?? payload.email.split("@")[0],
-      lastName: payload.family_name ?? "",
+      firstName: payload.given_name ?? payload.email.split('@')[0],
+      lastName: payload.family_name ?? '',
       verifiedEmail: payload.email_verified ? payload.email : undefined,
       profileImageUrl: payload.picture,
     });

--- a/server/src/lib/auth/index.ts
+++ b/server/src/lib/auth/index.ts
@@ -1,1 +1,1 @@
-export { signup, login, googleSignIn } from "./auth.lib";
+export { signup, login, googleSignIn } from './auth.lib';

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -10,8 +10,7 @@ function enableLogger(): void {
 
 function log(...args: unknown[]): void {
   if (
-    (process.env.NODE_ENV !== "test" ||
-      process.env.LOGGING_LEVEL === "verbose") &&
+    (process.env.NODE_ENV !== 'test' || process.env.LOGGING_LEVEL === 'verbose') &&
     !_suppressOutput
   ) {
     console.log(...args);
@@ -21,7 +20,7 @@ function log(...args: unknown[]): void {
 function error(...args: unknown[]): void {
   if (
     !_suppressOutput &&
-    (process.env.NODE_ENV !== "test" || process.env.LOGGING_LEVEL === "verbose")
+    (process.env.NODE_ENV !== 'test' || process.env.LOGGING_LEVEL === 'verbose')
   ) {
     console.error(...args);
   }

--- a/server/src/middleware/errorHandler.test.ts
+++ b/server/src/middleware/errorHandler.test.ts
@@ -1,7 +1,7 @@
-import { assert } from "chai";
-import { errorHandler } from "./errorHandler";
-import { NotFoundError, ValidationError, AppError } from "../utils/errors";
-import { NextFunction, Request, Response } from "express";
+import { assert } from 'chai';
+import { errorHandler } from './errorHandler';
+import { NotFoundError, ValidationError, AppError } from '../utils/errors';
+import { NextFunction, Request, Response } from 'express';
 
 type MockResponse = Partial<Response> & {
   statusCode?: number;
@@ -22,73 +22,61 @@ function createMockRes(): MockResponse {
   };
 }
 
-describe("errorHandler", () => {
-  it("translates known errors to status codes", () => {
-    const req = { path: "/test", method: "GET" } as Request;
+describe('errorHandler', () => {
+  it('translates known errors to status codes', () => {
+    const req = { path: '/test', method: 'GET' } as Request;
     const res = createMockRes();
 
-    errorHandler(
-      new NotFoundError("missing"),
-      req,
-      res as Response,
-      (() => {}) as NextFunction,
-    );
+    errorHandler(new NotFoundError('missing'), req, res as Response, (() => {}) as NextFunction);
 
     assert.equal(res.statusCode, 404);
     assert.deepEqual(res.jsonPayload, {
       error: {
-        message: "missing",
+        message: 'missing',
       },
     });
   });
 
-  it("includes validation data when available", () => {
-    const req = { path: "/validation", method: "POST" } as Request;
+  it('includes validation data when available', () => {
+    const req = { path: '/validation', method: 'POST' } as Request;
     const res = createMockRes();
-    const validationError = new ValidationError("Invalid data", [
-      { field: "name" },
-    ]);
+    const validationError = new ValidationError('Invalid data', [{ field: 'name' }]);
 
-    errorHandler(
-      validationError,
-      req,
-      res as Response,
-      (() => {}) as NextFunction,
-    );
+    errorHandler(validationError, req, res as Response, (() => {}) as NextFunction);
 
     assert.equal(res.statusCode, 400);
     assert.deepEqual(res.jsonPayload, {
       error: {
-        message: "Invalid data",
-        data: [{ field: "name" }],
+        message: 'Invalid data',
+        data: [{ field: 'name' }],
       },
     });
   });
 
-  it("falls back to 500 for unknown errors", () => {
-    const req = { path: "/boom", method: "GET" } as Request;
+  it('falls back to 500 for unknown errors', () => {
+    const req = { path: '/boom', method: 'GET' } as Request;
     const res = createMockRes();
-    const err = new Error("boom");
+    const err = new Error('boom');
 
     errorHandler(err, req, res as Response, (() => {}) as NextFunction);
 
     assert.equal(res.statusCode, 500);
     assert.deepEqual(res.jsonPayload, {
       error: {
-        message: "boom",
+        message: 'boom',
       },
     });
   });
 
-  it("does nothing when headers already sent", () => {
-    const req = { path: "/sent", method: "GET" } as Request;
+  it('does nothing when headers already sent', () => {
+    const req = { path: '/sent', method: 'GET' } as Request;
     const nextCalls: unknown[] = [];
     const res: MockResponse = {
       headersSent: true,
     };
 
     errorHandler(
-      new AppError("irrelevant"),
+      new AppError('irrelevant'),
       req,
       res as Response,
       ((err) => nextCalls.push(err)) as NextFunction,

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,5 +1,5 @@
-import { NextFunction, Request, Response } from "express";
-import logger from "../logger";
+import { NextFunction, Request, Response } from 'express';
+import logger from '../logger';
 import {
   AppError,
   AuthenticationError,
@@ -8,12 +8,11 @@ import {
   PermissionError,
   ServerError,
   ValidationError,
-} from "../utils/errors";
+} from '../utils/errors';
 
 function isSequelizeValidationError(error: Error): boolean {
   return (
-    error.name === "SequelizeValidationError" ||
-    error.name === "SequelizeUniqueConstraintError"
+    error.name === 'SequelizeValidationError' || error.name === 'SequelizeUniqueConstraintError'
   );
 }
 
@@ -35,8 +34,7 @@ export function errorHandler(
     return next(err as Error);
   }
 
-  const error =
-    err instanceof Error ? (err as ErrorWithData) : new Error(String(err));
+  const error = err instanceof Error ? (err as ErrorWithData) : new Error(String(err));
 
   let statusCode = 500;
 
@@ -59,14 +57,12 @@ export function errorHandler(
   if (isSequelizeValidationError(error)) {
     statusCode = 400;
     const validationError = error as SequelizeValidationError;
-    const validationErrors: ValidationErrorItem[] = validationError.errors.map(
-      (item) => ({
-        field: item.path,
-        message: item.message,
-      }),
-    );
+    const validationErrors: ValidationErrorItem[] = validationError.errors.map((item) => ({
+      field: item.path,
+      message: item.message,
+    }));
 
-    logger.error("Validation Error", {
+    logger.error('Validation Error', {
       errors: validationErrors,
       path: req.path,
       method: req.method,
@@ -75,14 +71,14 @@ export function errorHandler(
 
     return res.status(statusCode).json({
       error: {
-        message: "Validation error",
+        message: 'Validation error',
         data: validationErrors,
       },
     });
   }
 
   if (error instanceof AppError) {
-    logger.error(`${error.name || "Error"}: ${error.message}`, {
+    logger.error(`${error.name || 'Error'}: ${error.message}`, {
       statusCode,
       stack: error.stack,
       data: error.data,
@@ -91,7 +87,7 @@ export function errorHandler(
       userId: (req as { user?: { id?: string } }).user?.id,
     });
   } else {
-    logger.error("Unhandled Server Error", {
+    logger.error('Unhandled Server Error', {
       error: error.message,
       stack: error.stack,
       path: req.path,
@@ -102,7 +98,7 @@ export function errorHandler(
 
   const errorResponse: { error: { message: string; data?: unknown } } = {
     error: {
-      message: error.message || "An unexpected error occurred",
+      message: error.message || 'An unexpected error occurred',
     },
   };
 
@@ -110,9 +106,9 @@ export function errorHandler(
     errorResponse.error.data = error.data;
   }
 
-  const isProd = process.env.NODE_ENV === "production";
+  const isProd = process.env.NODE_ENV === 'production';
   if (isProd && statusCode >= 500) {
-    errorResponse.error.message = "Internal Server Error";
+    errorResponse.error.message = 'Internal Server Error';
   }
 
   return res.status(statusCode).json(errorResponse);

--- a/server/src/queue/index.ts
+++ b/server/src/queue/index.ts
@@ -1,5 +1,5 @@
-import { Queue, Worker, Job } from "bullmq";
-import logger from "../logger";
+import { Queue, Worker, Job } from 'bullmq';
+import logger from '../logger';
 
 const REDIS_URL = process.env.REDIS_URL;
 
@@ -17,7 +17,7 @@ const defaultJobOptions = {
   removeOnFail: 50,
   attempts: 3,
   backoff: {
-    type: "exponential" as const,
+    type: 'exponential' as const,
     delay: 2000,
   },
 };
@@ -26,13 +26,13 @@ function getRedisConnection() {
   if (!REDIS_URL) return null;
 
   const redisUrl = new URL(REDIS_URL);
-  const isTLS = redisUrl.protocol === "rediss:";
+  const isTLS = redisUrl.protocol === 'rediss:';
 
   return {
     host: redisUrl.hostname,
     port: parseInt(redisUrl.port) || 6379,
     password: redisUrl.password || undefined,
-    db: process.env.NODE_ENV === "test" ? 1 : 0,
+    db: process.env.NODE_ENV === 'test' ? 1 : 0,
     ...(isTLS ? { tls: {} } : {}),
   };
 }
@@ -61,17 +61,17 @@ export function createWorker(
 
 export const readyPromise: Promise<void> = (() => {
   if (!connection) {
-    logger.log("Skipping Redis setup... REDIS_URL not found");
+    logger.log('Skipping Redis setup... REDIS_URL not found');
     return Promise.resolve();
   }
 
   return new Promise<void>((resolve, reject) => {
-    const testQueue = new Queue("_redis_health_check", { connection });
+    const testQueue = new Queue('_redis_health_check', { connection });
 
     testQueue
       .waitUntilReady()
       .then(() => {
-        logger.log("Redis connection established");
+        logger.log('Redis connection established');
         resolve();
       })
       .catch(reject)

--- a/server/src/scripts/checkEnv.ts
+++ b/server/src/scripts/checkEnv.ts
@@ -1,10 +1,10 @@
-import logger from "../logger";
-import { requiredEnvVars } from "../config/envVars";
+import logger from '../logger';
+import { requiredEnvVars } from '../config/envVars';
 
 function findMissingEnvVars(): string[] {
   return requiredEnvVars.filter((envVar) => {
     const value = process.env[envVar];
-    return value == null || value === "";
+    return value == null || value === '';
   });
 }
 
@@ -12,15 +12,15 @@ export function ensureRequiredEnvVars(): void {
   const missingEnvVars = findMissingEnvVars();
 
   if (missingEnvVars.length > 0) {
-    logger.always.error("Missing required environment variables:");
-    logger.always.error("");
+    logger.always.error('Missing required environment variables:');
+    logger.always.error('');
     for (const envVar of missingEnvVars) {
       logger.always.error(`- ${envVar}`);
     }
     process.exit(1);
   }
 
-  logger.always.log("All required environment variables are set.");
+  logger.always.log('All required environment variables are set.');
 }
 
 if (require.main === module) {

--- a/server/src/scripts/startWorker.ts
+++ b/server/src/scripts/startWorker.ts
@@ -1,7 +1,7 @@
 // import cron from "node-cron";
-import logger from "../logger";
-import { readyPromise as queueReadyPromise, isRedisEnabled } from "../queue";
-import { ensureRequiredEnvVars } from "./checkEnv";
+import logger from '../logger';
+import { readyPromise as queueReadyPromise, isRedisEnabled } from '../queue';
+import { ensureRequiredEnvVars } from './checkEnv';
 
 export async function startWorker(): Promise<void> {
   ensureRequiredEnvVars();
@@ -26,19 +26,19 @@ export async function startWorker(): Promise<void> {
     //   return { success: true };
     // });
 
-    logger.log("Queue workers initialized");
+    logger.log('Queue workers initialized');
   }
 
-  logger.log("Worker setup complete.");
+  logger.log('Worker setup complete.');
 
   // --- Graceful Shutdown ---
   const shutdown = () => {
-    logger.log("Worker shutting down...");
+    logger.log('Worker shutting down...');
     process.exit(0);
   };
 
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
 }
 
 if (require.main === module) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,14 +1,14 @@
-import bodyParser from "body-parser";
-import compression from "compression";
-import express from "express";
-import bearerToken from "express-bearer-token";
-import http from "http";
-import morgan from "morgan";
-import addRoutes from "./api/routes";
-import config from "./config/config";
-import addDocRoutes from "./docs";
-import logger from "./logger";
-import { errorHandler } from "./middleware/errorHandler";
+import bodyParser from 'body-parser';
+import compression from 'compression';
+import express from 'express';
+import bearerToken from 'express-bearer-token';
+import http from 'http';
+import morgan from 'morgan';
+import addRoutes from './api/routes';
+import config from './config/config';
+import addDocRoutes from './docs';
+import logger from './logger';
+import { errorHandler } from './middleware/errorHandler';
 
 export type AppWithIsReadyPromise = express.Application & {
   isReadyPromise: Promise<void>;
@@ -18,14 +18,14 @@ const port = config.PORT;
 const app = express() as unknown as AppWithIsReadyPromise;
 
 app.use(function (req, res, next) {
-  res.header("Access-Control-Allow-Credentials", "true");
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE");
+  res.header('Access-Control-Allow-Credentials', 'true');
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
   res.header(
-    "Access-Control-Allow-Headers",
-    "X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept, Authorization",
+    'Access-Control-Allow-Headers',
+    'X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept, Authorization',
   );
-  if ("OPTIONS" === req.method) {
+  if ('OPTIONS' === req.method) {
     res.status(200).end();
   } else {
     next();
@@ -35,8 +35,8 @@ app.use(function (req, res, next) {
 // Express 5 makes req.query a read-only getter. Restore writable behavior
 // so existing middleware (convertQueryParamToDate, etc.) can mutate it.
 app.use(function (req, _res, next) {
-  Object.defineProperty(req, "query", {
-    ...Object.getOwnPropertyDescriptor(req, "query"),
+  Object.defineProperty(req, 'query', {
+    ...Object.getOwnPropertyDescriptor(req, 'query'),
     value: req.query,
     writable: true,
   });
@@ -44,7 +44,7 @@ app.use(function (req, _res, next) {
 });
 
 // Express 5 defaults to "simple" query parser; use "extended" (qs) for nested object support
-app.set("query parser", "extended");
+app.set('query parser', 'extended');
 
 app.use(bearerToken());
 app.use(compression());
@@ -53,8 +53,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 const setupPromises: Promise<unknown>[] = [];
 
-if (config.NODE_ENV !== "test") {
-  app.use(morgan("dev"));
+if (config.NODE_ENV !== 'test') {
+  app.use(morgan('dev'));
 }
 
 const server = http.createServer(app);

--- a/server/src/test/mochaSetup.test.js
+++ b/server/src/test/mochaSetup.test.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 /*
  * Global setup code for mocha tests
  * note: I think this works (executes first) because
@@ -25,15 +25,13 @@ var __awaiter =
       }
       function rejected(value) {
         try {
-          step(generator["throw"](value));
+          step(generator['throw'](value));
         } catch (e) {
           reject(e);
         }
       }
       function step(result) {
-        result.done
-          ? resolve(result.value)
-          : adopt(result.value).then(fulfilled, rejected);
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
       }
       step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
@@ -43,10 +41,10 @@ var __importDefault =
   function (mod) {
     return mod && mod.__esModule ? mod : { default: mod };
   };
-Object.defineProperty(exports, "__esModule", { value: true });
-const mocha_1 = require("mocha");
+Object.defineProperty(exports, '__esModule', { value: true });
+const mocha_1 = require('mocha');
 // import db from '../db';
-const server_1 = __importDefault(require("../server"));
+const server_1 = __importDefault(require('../server'));
 (0, mocha_1.before)(function () {
   return __awaiter(this, void 0, void 0, function* () {
     this.timeout(5000);

--- a/server/src/test/mochaSetup.test.ts
+++ b/server/src/test/mochaSetup.test.ts
@@ -1,13 +1,13 @@
-import { after, afterEach, before } from "mocha";
-import nock from "nock";
-import { performance } from "node:perf_hooks";
-import app from "../server";
-import { clearDatabase } from "./test.helpers";
+import { after, afterEach, before } from 'mocha';
+import nock from 'nock';
+import { performance } from 'node:perf_hooks';
+import app from '../server';
+import { clearDatabase } from './test.helpers';
 
 const testRunStart = performance.now();
 
 nock.disableNetConnect();
-nock.enableNetConnect("127.0.0.1");
+nock.enableNetConnect('127.0.0.1');
 
 before(async function (this: Mocha.Context) {
   this.timeout(5000);
@@ -23,8 +23,6 @@ after(function () {
   nock.cleanAll();
   nock.restore();
 
-  const durationSeconds = ((performance.now() - testRunStart) / 1000).toFixed(
-    2,
-  );
+  const durationSeconds = ((performance.now() - testRunStart) / 1000).toFixed(2);
   console.log(`Total test duration: ${durationSeconds}s`);
 });

--- a/server/src/test/test.helpers.ts
+++ b/server/src/test/test.helpers.ts
@@ -1,14 +1,14 @@
-import { assert } from "chai";
-import nock from "nock";
-import { Model, ModelStatic } from "sequelize";
-import config from "../config/config";
-import sequelize from "../db/sequelize";
-import logger from "../logger";
+import { assert } from 'chai';
+import nock from 'nock';
+import { Model, ModelStatic } from 'sequelize';
+import config from '../config/config';
+import sequelize from '../db/sequelize';
+import logger from '../logger';
 
 export async function clearDatabase() {
-  if (config.NODE_ENV !== "test") return;
+  if (config.NODE_ENV !== 'test') return;
 
-  await sequelize.query("SET session_replication_role = replica;");
+  await sequelize.query('SET session_replication_role = replica;');
 
   const models = sequelize.models;
   for (const modelName of Object.keys(models)) {
@@ -19,7 +19,7 @@ export async function clearDatabase() {
     });
   }
 
-  await sequelize.query("SET session_replication_role = DEFAULT;");
+  await sequelize.query('SET session_replication_role = DEFAULT;');
 }
 
 export async function waitForInstanceToExist<T extends Model>(
@@ -33,7 +33,7 @@ export async function waitForInstanceToExist<T extends Model>(
     return results[0];
   }
   if (elapsed >= timeout) {
-    throw assert.fail("model failed to create within timeout");
+    throw assert.fail('model failed to create within timeout');
   }
   return waitForInstanceToExist(model, query, timeout, elapsed + 10);
 }
@@ -66,10 +66,8 @@ export async function assertInstancePropertyEventuallyEquals(
 
 export function checkAndClearNocks() {
   if (!nock.isDone()) {
-    logger.always.log(
-      "remaining Nocks: " + JSON.stringify(nock.pendingMocks(), null, 2),
-    );
-    throw assert.fail("Not all nock interceptors were used!");
+    logger.always.log('remaining Nocks: ' + JSON.stringify(nock.pendingMocks(), null, 2));
+    throw assert.fail('Not all nock interceptors were used!');
   }
   nock.cleanAll();
 }
@@ -79,8 +77,8 @@ export function extractIds(arr: Array<{ id: unknown }>) {
 }
 
 export function parseJwt(token: string): unknown {
-  const base64Url = token.split(".")[1];
-  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-  const buff = Buffer.from(base64, "base64");
-  return JSON.parse(buff.toString("ascii"));
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const buff = Buffer.from(base64, 'base64');
+  return JSON.parse(buff.toString('ascii'));
 }

--- a/server/src/test/testDataGenerator.ts
+++ b/server/src/test/testDataGenerator.ts
@@ -1,10 +1,10 @@
-import { faker } from "@faker-js/faker";
-import config from "../config/config";
-import User from "../db/models/user.model";
-import { generateToken } from "../utils/jwt";
+import { faker } from '@faker-js/faker';
+import config from '../config/config';
+import User from '../db/models/user.model';
+import { generateToken } from '../utils/jwt';
 
-if (config.NODE_ENV !== "test") {
-  throw new Error("testDataGenerator can only be used in test environment");
+if (config.NODE_ENV !== 'test') {
+  throw new Error('testDataGenerator can only be used in test environment');
 }
 
 type UserOverrides = Partial<{
@@ -16,7 +16,7 @@ type UserOverrides = Partial<{
   profileImageUrl: string;
   verifiedEmail: string;
   passwordHash: string;
-  role: "admin" | "user" | "guest";
+  role: 'admin' | 'user' | 'guest';
 }>;
 
 export async function createUser(overrides: UserOverrides = {}) {
@@ -28,7 +28,7 @@ export async function createUser(overrides: UserOverrides = {}) {
     displayName: overrides.displayName ?? `${firstName} ${lastName}`,
     email: overrides.email ?? faker.internet.email(),
     profileImageUrl: overrides.profileImageUrl ?? faker.image.avatar(),
-    role: overrides.role ?? "user",
+    role: overrides.role ?? 'user',
     ...overrides,
   });
 }

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,13 +1,13 @@
-import "express";
+import 'express';
 
-declare module "express-serve-static-core" {
+declare module 'express-serve-static-core' {
   interface Request {
     auth?: {
       id: string;
       email: string;
       displayName?: string;
       profileImageUrl?: string;
-      role: "admin" | "user" | "guest";
+      role: 'admin' | 'user' | 'guest';
       [key: string]: string | number | undefined;
     };
   }

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -22,31 +22,27 @@ export class ValidationError extends AppError {}
 export class ConflictError extends AppError {}
 
 export class ServerError extends AppError {
-  constructor(message = "An unexpected error occurred", data?: unknown) {
+  constructor(message = 'An unexpected error occurred', data?: unknown) {
     super(message, data);
   }
 }
 
 export const ErrorMessages = {
-  RESOURCE_NOT_FOUND: "The requested resource could not be found.",
-  AUTHENTICATION_REQUIRED:
-    "Authentication is required to access this resource.",
-  ACCESS_TOKEN_REQUIRED:
-    "Invalid credentials: accessToken required for this endpoint.",
-  BASIC_AUTH_REQUIRED: "Basic authentication is required for this endpoint.",
-  FORBIDDEN: "You do not have permission to perform this action.",
-  ADMIN_REQUIRED: "Admin role is required for this action.",
-  VALIDATION_FAILED: "The provided data is invalid.",
-  INVALID_UUID_FORMAT: "Invalid UUID format.",
-  CONFLICT: "The request could not be completed due to a conflict.",
-  SERVER_ERROR: "An unexpected error occurred.",
+  RESOURCE_NOT_FOUND: 'The requested resource could not be found.',
+  AUTHENTICATION_REQUIRED: 'Authentication is required to access this resource.',
+  ACCESS_TOKEN_REQUIRED: 'Invalid credentials: accessToken required for this endpoint.',
+  BASIC_AUTH_REQUIRED: 'Basic authentication is required for this endpoint.',
+  FORBIDDEN: 'You do not have permission to perform this action.',
+  ADMIN_REQUIRED: 'Admin role is required for this action.',
+  VALIDATION_FAILED: 'The provided data is invalid.',
+  INVALID_UUID_FORMAT: 'Invalid UUID format.',
+  CONFLICT: 'The request could not be completed due to a conflict.',
+  SERVER_ERROR: 'An unexpected error occurred.',
 
-  invalidUuidFormat: (paramName: string) =>
-    `Invalid UUID format for parameter: ${paramName}`,
+  invalidUuidFormat: (paramName: string) => `Invalid UUID format for parameter: ${paramName}`,
   invalidBodyField: (field: string, allowedValues: string[]) =>
-    `Invalid value for '${field}'. Allowed values: ${allowedValues.join(", ")}`,
-  missingPermission: (permission: string) =>
-    `Missing required permission: ${permission}`,
+    `Invalid value for '${field}'. Allowed values: ${allowedValues.join(', ')}`,
+  missingPermission: (permission: string) => `Missing required permission: ${permission}`,
 } as const;
 
 export const createNotFoundError = (message: string, data?: unknown) =>

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -1,19 +1,14 @@
-import * as jwt from "jsonwebtoken";
-import User from "../db/models/user.model";
-import config from "../config/config";
+import * as jwt from 'jsonwebtoken';
+import User from '../db/models/user.model';
+import config from '../config/config';
 
 export function generateToken(user: User): Promise<string> {
   return new Promise((resolve, reject) => {
-    jwt.sign(
-      user.jwtRepr(),
-      config.JWT_SECRET!,
-      { algorithm: "HS256" },
-      function (err, token) {
-        if (err || !token) {
-          return reject(err || new Error("Failed to generate token"));
-        }
-        return resolve(token);
-      },
-    );
+    jwt.sign(user.jwtRepr(), config.JWT_SECRET!, { algorithm: 'HS256' }, function (err, token) {
+      if (err || !token) {
+        return reject(err || new Error('Failed to generate token'));
+      }
+      return resolve(token);
+    });
   });
 }

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -1,5 +1,5 @@
-import logger from "./logger";
-import { startWorker } from "./scripts/startWorker";
+import logger from './logger';
+import { startWorker } from './scripts/startWorker';
 
 startWorker().catch((err) => {
   logger.error(err);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -112,5 +112,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["examples", "node_modules", "dist", "eslint.config.js"]
+  "exclude": ["examples", "node_modules", "dist", "eslint.config.js", "prettier.config.cjs"]
 }


### PR DESCRIPTION
## Summary

- **`scripts/init-project.sh`** — prompts for project name, replaces placeholder names in package.json, README title, .env COMPOSE_PROJECT_NAME, and API docs title
- **README rewrite** — feature overview (auth endpoints, client auth flow, JWT, routing), quick start referencing init script, optional features section (Redis/BullMQ, Google OAuth, metrics)
- **`/create-feature` skill** — new Claude Code skill for creating client features (service + context + page + route) with reference implementations pointing to existing auth code
- **CLAUDE.md updates** — expanded client codebase map, added `/create-feature` to task-type reference table
- **Skill updates** — `/create-endpoint` and `/create-lib` now reference auth as the primary example alongside healthCheck
- **Prettier** — ran prettier on all files

## Test plan

- [ ] Verify `scripts/init-project.sh` runs and replaces names correctly on a fresh clone
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `/create-feature` skill appears in Claude Code skill list
- [ ] Verify existing tests still pass (`make test-server`, `make test-client`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)