### PR TITLE
Add user endpoint (Stage 3)

### DIFF
--- a/server/src/api/routes.ts
+++ b/server/src/api/routes.ts
@@ -1,10 +1,12 @@
 import { Application } from 'express';
 import authApi from './auth';
 import healthCheckApi from './healthCheck';
+import userApi from './user';
 
 function addRoutes(app: Application) {
   app.use('/v1/auth', authApi);
   app.use('/v1/healthCheck', healthCheckApi);
+  app.use('/v1/users', userApi);
 }
 
 export default addRoutes;

--- a/server/src/api/user/index.ts
+++ b/server/src/api/user/index.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import { authenticateAccessToken, isOperatingOnSelf, requireRoleOfAtLeast } from '../security';
+import { validateUUIDsInParams, checkBodyForAtLeastOneOf, oneOf } from '../validation';
+import { handleGetMe, handleGetUser, handleUpdateUser } from './user.api';
+
+const router = express.Router();
+
+const UPDATABLE_FIELDS = ['firstName', 'lastName', 'displayName', 'profileImageUrl'];
+
+router.get('/me', authenticateAccessToken, handleGetMe);
+
+router.get(
+  '/:userId',
+  authenticateAccessToken,
+  validateUUIDsInParams(['userId']),
+  oneOf([isOperatingOnSelf('userId'), requireRoleOfAtLeast('admin')]),
+  handleGetUser,
+);
+
+router.put(
+  '/:userId',
+  authenticateAccessToken,
+  validateUUIDsInParams(['userId']),
+  oneOf([isOperatingOnSelf('userId'), requireRoleOfAtLeast('admin')]),
+  checkBodyForAtLeastOneOf(UPDATABLE_FIELDS),
+  handleUpdateUser,
+);
+
+export default router;

--- a/server/src/api/user/user.api.docs.yaml
+++ b/server/src/api/user/user.api.docs.yaml
@@ -1,0 +1,107 @@
+paths:
+  /v1/users/me:
+    get:
+      tags:
+        - Users
+      summary: Get current user
+      description: Returns the authenticated user's profile.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+        '401':
+          description: Authentication required
+
+  /v1/users/{userId}:
+    get:
+      tags:
+        - Users
+      summary: Get user by ID
+      description: Returns a user by ID. Accessible by the user themselves or an admin.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: User profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+        '400':
+          description: Invalid UUID format
+        '401':
+          description: Authentication required
+        '403':
+          description: Forbidden — not self or admin
+        '404':
+          description: User not found
+
+    put:
+      tags:
+        - Users
+      summary: Update user
+      description: Update a user's profile. Accessible by the user themselves or an admin.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                  example: Jane
+                lastName:
+                  type: string
+                  example: Doe
+                displayName:
+                  type: string
+                  example: Jane Doe
+                profileImageUrl:
+                  type: string
+                  example: https://example.com/photo.jpg
+      responses:
+        '200':
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserJwtRepr'
+        '400':
+          description: Invalid UUID or no updatable fields provided
+        '401':
+          description: Authentication required
+        '403':
+          description: Forbidden — not self or admin
+        '404':
+          description: User not found

--- a/server/src/api/user/user.api.test.ts
+++ b/server/src/api/user/user.api.test.ts
@@ -1,0 +1,158 @@
+import { assert } from 'chai';
+import request from 'supertest';
+import app from '../../server';
+import { createUser, createUserWithToken } from '../../test/testDataGenerator';
+
+describe('User API', function () {
+  describe('GET /v1/users/me', function () {
+    it('returns the authenticated user', async function () {
+      const { user, token } = await createUserWithToken({ firstName: 'Me' });
+
+      const res = await request(app)
+        .get('/v1/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      assert.equal(res.body.user.id, user.id);
+      assert.equal(res.body.user.firstName, 'Me');
+    });
+
+    it('returns 401 without authentication', async function () {
+      await request(app).get('/v1/users/me').expect(401);
+    });
+  });
+
+  describe('GET /v1/users/:userId', function () {
+    it('allows a user to get their own profile', async function () {
+      const { user, token } = await createUserWithToken({ firstName: 'Self' });
+
+      const res = await request(app)
+        .get(`/v1/users/${user.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      assert.equal(res.body.user.id, user.id);
+      assert.equal(res.body.user.firstName, 'Self');
+    });
+
+    it('allows an admin to get any user', async function () {
+      const { token: adminToken } = await createUserWithToken({ role: 'admin' });
+      const targetUser = await createUser({ firstName: 'Target' });
+
+      const res = await request(app)
+        .get(`/v1/users/${targetUser.id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      assert.equal(res.body.user.id, targetUser.id);
+      assert.equal(res.body.user.firstName, 'Target');
+    });
+
+    it('returns 403 when a non-admin tries to get another user', async function () {
+      const { token } = await createUserWithToken();
+      const otherUser = await createUser();
+
+      await request(app)
+        .get(`/v1/users/${otherUser.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(403);
+    });
+
+    it('returns 404 for non-existent user', async function () {
+      const { token } = await createUserWithToken({ role: 'admin' });
+
+      await request(app)
+        .get('/v1/users/00000000-0000-0000-0000-000000000000')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('returns 400 for invalid UUID', async function () {
+      const { token } = await createUserWithToken();
+
+      await request(app)
+        .get('/v1/users/not-a-uuid')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(400);
+    });
+
+    it('returns 401 without authentication', async function () {
+      await request(app).get('/v1/users/00000000-0000-0000-0000-000000000000').expect(401);
+    });
+  });
+
+  describe('PUT /v1/users/:userId', function () {
+    it('allows a user to update their own profile', async function () {
+      const { user, token } = await createUserWithToken({ firstName: 'Old' });
+
+      const res = await request(app)
+        .put(`/v1/users/${user.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ firstName: 'New' })
+        .expect(200);
+
+      assert.equal(res.body.user.firstName, 'New');
+    });
+
+    it('allows an admin to update any user', async function () {
+      const { token: adminToken } = await createUserWithToken({ role: 'admin' });
+      const targetUser = await createUser({ firstName: 'Before' });
+
+      const res = await request(app)
+        .put(`/v1/users/${targetUser.id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ firstName: 'After' })
+        .expect(200);
+
+      assert.equal(res.body.user.firstName, 'After');
+    });
+
+    it('returns 403 when a non-admin tries to update another user', async function () {
+      const { token } = await createUserWithToken();
+      const otherUser = await createUser();
+
+      await request(app)
+        .put(`/v1/users/${otherUser.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ firstName: 'Hacked' })
+        .expect(403);
+    });
+
+    it('returns 400 when no updatable fields are provided', async function () {
+      const { user, token } = await createUserWithToken();
+
+      await request(app)
+        .put(`/v1/users/${user.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({})
+        .expect(400);
+    });
+
+    it('returns 400 for invalid UUID', async function () {
+      const { token } = await createUserWithToken();
+
+      await request(app)
+        .put('/v1/users/not-a-uuid')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ firstName: 'Test' })
+        .expect(400);
+    });
+
+    it('returns 404 for non-existent user', async function () {
+      const { token } = await createUserWithToken({ role: 'admin' });
+
+      await request(app)
+        .put('/v1/users/00000000-0000-0000-0000-000000000000')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ firstName: 'Ghost' })
+        .expect(404);
+    });
+
+    it('returns 401 without authentication', async function () {
+      await request(app)
+        .put('/v1/users/00000000-0000-0000-0000-000000000000')
+        .send({ firstName: 'Test' })
+        .expect(401);
+    });
+  });
+});

--- a/server/src/api/user/user.api.ts
+++ b/server/src/api/user/user.api.ts
@@ -1,0 +1,37 @@
+import { NextFunction, Request, Response } from 'express';
+import { AuthenticatedRequest } from '../security';
+import { getUser, updateUser } from '../../lib/user';
+
+export async function handleGetMe(req: Request, res: Response, next: NextFunction) {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const user = await getUser(authReq.auth.id);
+    res.status(200).json({ user: user.jwtRepr() });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleGetUser(req: Request, res: Response, next: NextFunction) {
+  try {
+    const user = await getUser(req.params.userId as string);
+    res.status(200).json({ user: user.jwtRepr() });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleUpdateUser(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { firstName, lastName, displayName, profileImageUrl } = req.body;
+    const user = await updateUser(req.params.userId as string, {
+      firstName,
+      lastName,
+      displayName,
+      profileImageUrl,
+    });
+    res.status(200).json({ user: user.jwtRepr() });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/server/src/lib/user/index.ts
+++ b/server/src/lib/user/index.ts
@@ -1,0 +1,1 @@
+export { getUser, updateUser } from './user.lib';

--- a/server/src/lib/user/user.lib.test.ts
+++ b/server/src/lib/user/user.lib.test.ts
@@ -1,0 +1,61 @@
+import { assert } from 'chai';
+import { createUser } from '../../test/testDataGenerator';
+import { getUser, updateUser } from './user.lib';
+
+describe('User Lib', function () {
+  describe('getUser', function () {
+    it('returns a user by id', async function () {
+      const user = await createUser({ firstName: 'Jane', lastName: 'Doe' });
+      const found = await getUser(user.id);
+      assert.equal(found.id, user.id);
+      assert.equal(found.firstName, 'Jane');
+      assert.equal(found.lastName, 'Doe');
+    });
+
+    it('throws NotFoundError for non-existent id', async function () {
+      try {
+        await getUser('00000000-0000-0000-0000-000000000000');
+        assert.fail('should have thrown');
+      } catch (err: unknown) {
+        assert.equal((err as Error).constructor.name, 'NotFoundError');
+      }
+    });
+  });
+
+  describe('updateUser', function () {
+    it('updates firstName', async function () {
+      const user = await createUser({ firstName: 'Old' });
+      const updated = await updateUser(user.id, { firstName: 'New' });
+      assert.equal(updated.firstName, 'New');
+    });
+
+    it('updates lastName', async function () {
+      const user = await createUser({ lastName: 'OldLast' });
+      const updated = await updateUser(user.id, { lastName: 'NewLast' });
+      assert.equal(updated.lastName, 'NewLast');
+    });
+
+    it('updates displayName', async function () {
+      const user = await createUser({ displayName: 'OldDisplay' });
+      const updated = await updateUser(user.id, { displayName: 'NewDisplay' });
+      assert.equal(updated.displayName, 'NewDisplay');
+    });
+
+    it('updates profileImageUrl', async function () {
+      const user = await createUser();
+      const updated = await updateUser(user.id, {
+        profileImageUrl: 'https://example.com/new.jpg',
+      });
+      assert.equal(updated.profileImageUrl, 'https://example.com/new.jpg');
+    });
+
+    it('throws NotFoundError for non-existent id', async function () {
+      try {
+        await updateUser('00000000-0000-0000-0000-000000000000', { firstName: 'Test' });
+        assert.fail('should have thrown');
+      } catch (err: unknown) {
+        assert.equal((err as Error).constructor.name, 'NotFoundError');
+      }
+    });
+  });
+});

--- a/server/src/lib/user/user.lib.ts
+++ b/server/src/lib/user/user.lib.ts
@@ -1,0 +1,27 @@
+import User from '../../db/models/user.model';
+import { NotFoundError } from '../../utils/errors';
+
+export async function getUser(userId: string): Promise<User> {
+  const user = await User.findByPk(userId);
+  if (!user) {
+    throw new NotFoundError('User not found');
+  }
+  return user;
+}
+
+export async function updateUser(
+  userId: string,
+  updates: {
+    firstName?: string;
+    lastName?: string;
+    displayName?: string;
+    profileImageUrl?: string;
+  },
+): Promise<User> {
+  const user = await User.findByPk(userId);
+  if (!user) {
+    throw new NotFoundError('User not found');
+  }
+  await user.update(updates);
+  return user;
+}


### PR DESCRIPTION
## Summary
- Adds `GET /v1/users/me` — returns the authenticated user's profile
- Adds `GET /v1/users/:userId` — get user by ID (self or admin)
- Adds `PUT /v1/users/:userId` — update user profile (self or admin)
- Lib layer with `getUser` and `updateUser` business logic
- 22 new tests (7 lib + 15 integration), all 85 total tests pass
- OpenAPI docs in `user.api.docs.yaml`

## Test plan
- [x] `make test-server` — all 85 tests pass
- [x] `make lint-server` — clean
- [x] `make build-server` — compiles
- [x] `make prettier-all` — formatted