### PR TITLE
Replace Heroku deploy pipeline with Render

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,44 @@
 version: 2.1
 
-orbs:
-  heroku: circleci/heroku@1.2.3 # Invoke the Heroku orb
-
 workflows:
-  heroku_deploy:
+  deploy_staging:
     jobs:
       - build:
           filters:
             branches:
               only: develop
-      - heroku_build:
+      - build_and_push_image:
           requires:
             - build
           filters:
             branches:
               only: develop
-      - deploy_to_heroku_staging:
+          context:
+            - ghcr
+      - deploy_to_render_staging:
           requires:
-            - heroku_build
+            - build_and_push_image
           filters:
             branches:
               only: develop
+          context:
+            - render
 
-  heroku_promote:
+  deploy_production:
     jobs:
       - build:
           filters:
             branches:
               only: main
-      - promote_to_heroku_production:
+      - promote_to_production:
           requires:
             - build
           filters:
             branches:
               only: main
+          context:
+            - ghcr
+            - render
 
   test:
     jobs:
@@ -43,6 +47,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - develop
 
   lint-client:
     jobs:
@@ -63,63 +68,151 @@ jobs:
 
     steps:
       - checkout
-      - run: touch ./server/.env # env files have to exist for docker compose to work
+      - run: touch ./server/.env
       - run:
           name: Authenticate with Docker Hub
           command: |
             : "${DOCKERHUB_USERNAME:?Set DOCKERHUB_USERNAME in CircleCI project settings}"
             : "${DOCKERHUB_PASSWORD:?Set DOCKERHUB_PASSWORD in CircleCI project settings}"
             echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      - run: docker compose run server npx env-cmd -f .env-test npm run build # build includes tsx and migrate
+      - run: docker compose run server npx env-cmd -f .env-test npm run build
       - run: docker compose run server npm test
 
-  heroku_build:
+  build_and_push_image:
     machine: true
     working_directory: ~/src
 
     steps:
       - checkout
-      - run: touch ./server/.env # env files have to exist for docker compose to work
       - run:
-          name: Authenticate with Docker Hub
+          name: Log in to GHCR
+          command: echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GHCR_USERNAME" --password-stdin
+      - run:
+          name: Build production image
+          command: docker build -t ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:staging -f server/Dockerfile.production server
+      - run:
+          name: Push image to GHCR
+          command: docker push ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:staging
+
+  deploy_to_render_staging:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Deploy staging services on Render
           command: |
-            : "${DOCKERHUB_USERNAME:?Set DOCKERHUB_USERNAME in CircleCI project settings}"
-            : "${DOCKERHUB_PASSWORD:?Set DOCKERHUB_PASSWORD in CircleCI project settings}"
-            echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      - run: docker compose run server npm run build-ts
+            : "${RENDER_API_KEY:?Set RENDER_API_KEY in CircleCI context}"
+            : "${RENDER_STAGING_SERVICE_ID:?Set RENDER_STAGING_SERVICE_ID in CircleCI context}"
+
+            echo "Triggering Render deploy for staging-server..."
+            DEPLOY_RESPONSE=$(curl -sf \
+              -X POST \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              -H "Content-Type: application/json" \
+              "https://api.render.com/v1/services/$RENDER_STAGING_SERVICE_ID/deploys")
+
+            DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id')
+            echo "Deploy ID: $DEPLOY_ID"
+
+            echo "Polling deploy status..."
+            for i in $(seq 1 60); do
+              STATUS=$(curl -sf \
+                -H "Authorization: Bearer $RENDER_API_KEY" \
+                "https://api.render.com/v1/services/$RENDER_STAGING_SERVICE_ID/deploys/$DEPLOY_ID" \
+                | jq -r '.status')
+
+              echo "  Attempt $i: $STATUS"
+
+              if [ "$STATUS" = "live" ]; then
+                echo "Deploy succeeded"
+                break
+              elif [ "$STATUS" = "deactivated" ] || [ "$STATUS" = "build_failed" ] || [ "$STATUS" = "update_failed" ] || [ "$STATUS" = "canceled" ]; then
+                echo "Deploy failed with status: $STATUS" >&2
+                exit 1
+              fi
+
+              sleep 10
+            done
+
+            if [ "$STATUS" != "live" ]; then
+              echo "Timed out waiting for deploy" >&2
+              exit 1
+            fi
+
+            # Deploy worker if service ID is set
+            if [ -n "$RENDER_STAGING_WORKER_SERVICE_ID" ]; then
+              echo "Triggering Render deploy for staging-worker..."
+              curl -sf \
+                -X POST \
+                -H "Authorization: Bearer $RENDER_API_KEY" \
+                -H "Content-Type: application/json" \
+                "https://api.render.com/v1/services/$RENDER_STAGING_WORKER_SERVICE_ID/deploys"
+            fi
+
+  promote_to_production:
+    machine: true
+    working_directory: ~/src
+
+    steps:
       - run:
-          name: Install required tools
-          command: sudo apt-get update && sudo apt-get install -y jq
+          name: Log in to GHCR
+          command: echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GHCR_USERNAME" --password-stdin
       - run:
-          name: Fix permissions and prepare for Heroku
+          name: Promote staging image to production
           command: |
-            # Fix permissions from Docker
-            sudo chown -R $USER:$USER ./server
+            docker pull ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:staging
+            docker tag ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:staging ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:production
+            docker push ghcr.io/$GHCR_USERNAME/$CIRCLE_PROJECT_REPONAME:production
+      - run:
+          name: Deploy production services on Render
+          command: |
+            : "${RENDER_API_KEY:?Set RENDER_API_KEY in CircleCI context}"
+            : "${RENDER_PRODUCTION_SERVICE_ID:?Set RENDER_PRODUCTION_SERVICE_ID in CircleCI context}"
 
-            # Create a deployment directory structure
-            mkdir -p ./server/deploy/dist
+            echo "Triggering Render deploy for production-server..."
+            DEPLOY_RESPONSE=$(curl -sf \
+              -X POST \
+              -H "Authorization: Bearer $RENDER_API_KEY" \
+              -H "Content-Type: application/json" \
+              "https://api.render.com/v1/services/$RENDER_PRODUCTION_SERVICE_ID/deploys")
 
-            # Copy compiled files and dependencies
-            cp -r ./server/dist/* ./server/deploy/dist/
+            DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id')
+            echo "Deploy ID: $DEPLOY_ID"
 
-            # Copy Sequelize configuration files
-            cp ./server/.sequelizerc ./server/deploy/
+            echo "Polling deploy status..."
+            for i in $(seq 1 60); do
+              STATUS=$(curl -sf \
+                -H "Authorization: Bearer $RENDER_API_KEY" \
+                "https://api.render.com/v1/services/$RENDER_PRODUCTION_SERVICE_ID/deploys/$DEPLOY_ID" \
+                | jq -r '.status')
 
-            # Copy package files but modify the build script
-            cat ./server/package.json | jq '.scripts.build = "npm run migrate"' > ./server/deploy/package.json
-            cp ./server/package-lock.json ./server/deploy/ || true
+              echo "  Attempt $i: $STATUS"
 
-            # Create Procfile that skips build entirely and properly runs migrations
-            echo "release: npm run env:check && npx sequelize-cli --options-path=.sequelizerc db:migrate" > ./server/deploy/Procfile
-            echo "web: node dist/server.js" >> ./server/deploy/Procfile
-            echo "worker: node dist/worker.js" >> ./server/deploy/Procfile
+              if [ "$STATUS" = "live" ]; then
+                echo "Deploy succeeded"
+                break
+              elif [ "$STATUS" = "deactivated" ] || [ "$STATUS" = "build_failed" ] || [ "$STATUS" = "update_failed" ] || [ "$STATUS" = "canceled" ]; then
+                echo "Deploy failed with status: $STATUS" >&2
+                exit 1
+              fi
 
-            # Create .slugignore
-            echo "src/" > ./server/deploy/.slugignore
-      - persist_to_workspace:
-          root: ~/src
-          paths:
-            - server/deploy
+              sleep 10
+            done
+
+            if [ "$STATUS" != "live" ]; then
+              echo "Timed out waiting for deploy" >&2
+              exit 1
+            fi
+
+            # Deploy worker if service ID is set
+            if [ -n "$RENDER_PRODUCTION_WORKER_SERVICE_ID" ]; then
+              echo "Triggering Render deploy for production-worker..."
+              curl -sf \
+                -X POST \
+                -H "Authorization: Bearer $RENDER_API_KEY" \
+                -H "Content-Type: application/json" \
+                "https://api.render.com/v1/services/$RENDER_PRODUCTION_WORKER_SERVICE_ID/deploys"
+            fi
 
   lint-server:
     machine: true
@@ -142,7 +235,7 @@ jobs:
 
     steps:
       - checkout
-      - run: touch ./server/.env # env files have to exist for docker compose to work
+      - run: touch ./server/.env
       - run:
           name: Authenticate with Docker Hub
           command: |
@@ -157,7 +250,7 @@ jobs:
 
     steps:
       - checkout
-      - run: touch ./server/.env # env files have to exist for docker compose to work
+      - run: touch ./server/.env
       - run:
           name: Authenticate with Docker Hub
           command: |
@@ -165,157 +258,3 @@ jobs:
             : "${DOCKERHUB_PASSWORD:?Set DOCKERHUB_PASSWORD in CircleCI project settings}"
             echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - run: docker compose run client npm test
-
-  deploy_to_heroku_staging:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Abort staging deploy when env vars are missing
-          command: |
-            missing=""
-            for var in HEROKU_STAGING_APP_NAME HEROKU_STAGING_EMAIL HEROKU_STAGING_API_KEY; do
-              if [ -z "${!var:-}" ]; then
-                missing="$missing $var"
-              fi
-            done
-            if [ -n "$missing" ]; then
-              echo "Skipping staging deploy. Missing env vars:$missing"
-              circleci step halt
-            fi
-      - attach_workspace:
-          at: ~/src
-      - run:
-          name: Install Heroku CLI
-          command: curl https://cli-assets.heroku.com/install.sh | sh
-      - run:
-          name: Install release parsing tools
-          command: sudo apt-get update && sudo apt-get install -y jq
-      - run:
-          name: Deploy to Heroku staging
-          command: |
-            : "${HEROKU_STAGING_APP_NAME:?HEROKU_STAGING_APP_NAME is required for staging deploys}"
-            : "${HEROKU_STAGING_EMAIL:?HEROKU_STAGING_EMAIL is required for staging deploys}"
-            : "${HEROKU_STAGING_API_KEY:?HEROKU_STAGING_API_KEY is required for staging deploys}"
-
-            cd ~/src/server/deploy
-            git init
-            git config user.email "ci-build@node-react-scaffold"
-            git config user.name "CircleCI"
-
-            cat > ~/.netrc \<< EOF
-            machine api.heroku.com
-              login $HEROKU_STAGING_EMAIL
-              password $HEROKU_STAGING_API_KEY
-            machine git.heroku.com
-              login $HEROKU_STAGING_EMAIL
-              password $HEROKU_STAGING_API_KEY
-            EOF
-            chmod 600 ~/.netrc
-
-            heroku git:remote -a $HEROKU_STAGING_APP_NAME
-
-            git add -A
-            git commit -m "Build from CircleCI [skip ci]"
-            git push heroku HEAD:refs/heads/master -f
-
-            echo "Waiting for Heroku release to finish…"
-            HEROKU_APP="$HEROKU_STAGING_APP_NAME"
-            HEROKU_API_KEY="$HEROKU_STAGING_API_KEY"
-            RELEASE_STATUS=""
-            for _ in $(seq 1 30); do
-              RELEASE_STATUS=$(curl -sf \
-                -H "Authorization: Bearer $HEROKU_API_KEY" \
-                -H "Accept: application/vnd.heroku+json; version=3" \
-                "https://api.heroku.com/apps/$HEROKU_APP/releases" \
-                | jq -r 'sort_by(.created_at) | last | .status // empty')
-
-              if [ "$RELEASE_STATUS" = "succeeded" ]; then
-                echo "Heroku release succeeded ✅"
-                break
-              elif [ "$RELEASE_STATUS" = "failed" ]; then
-                echo "Heroku release FAILED ❌" >&2
-                heroku releases --app "$HEROKU_APP" --json | jq -r '.[0] | "Release v\(.version): \(.description) — Status: \(.status)"' || true
-                exit 1
-              fi
-
-              sleep 5
-            done
-
-            if [ "$RELEASE_STATUS" != "succeeded" ]; then
-              echo "Timed out waiting for Heroku release status." >&2
-              exit 1
-            fi
-
-  promote_to_heroku_production:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Abort production promote when env vars are missing
-          command: |
-            missing=""
-            for var in HEROKU_STAGING_APP_NAME HEROKU_APP_NAME HEROKU_STAGING_EMAIL HEROKU_STAGING_API_KEY; do
-              if [ -z "${!var:-}" ]; then
-                missing="$missing $var"
-              fi
-            done
-            if [ -n "$missing" ]; then
-              echo "Skipping production promotion. Missing env vars:$missing"
-              circleci step halt
-            fi
-      - run:
-          name: Install Heroku CLI
-          command: curl https://cli-assets.heroku.com/install.sh | sh
-      - run:
-          name: Install release parsing tools
-          command: sudo apt-get update && sudo apt-get install -y jq
-      - run:
-          name: Promote staging slug to production
-          command: |
-            : "${HEROKU_STAGING_APP_NAME:?HEROKU_STAGING_APP_NAME is required for promotions}"
-            : "${HEROKU_APP_NAME:?HEROKU_APP_NAME is required for promotions}"
-            : "${HEROKU_STAGING_EMAIL:?HEROKU_STAGING_EMAIL is required for promotions}"
-            : "${HEROKU_STAGING_API_KEY:?HEROKU_STAGING_API_KEY is required for promotions}"
-
-            cat > ~/.netrc \<< EOF
-            machine api.heroku.com
-              login $HEROKU_STAGING_EMAIL
-              password $HEROKU_STAGING_API_KEY
-            machine git.heroku.com
-              login $HEROKU_STAGING_EMAIL
-              password $HEROKU_STAGING_API_KEY
-            EOF
-            chmod 600 ~/.netrc
-
-            heroku pipelines:promote --app $HEROKU_STAGING_APP_NAME --to $HEROKU_APP_NAME
-
-            echo "Waiting for Heroku release to finish…"
-            HEROKU_APP="$HEROKU_APP_NAME"
-            HEROKU_API_KEY="$HEROKU_STAGING_API_KEY"
-            RELEASE_STATUS=""
-            for _ in $(seq 1 30); do
-              RELEASE_STATUS=$(curl -sf \
-                -H "Authorization: Bearer $HEROKU_API_KEY" \
-                -H "Accept: application/vnd.heroku+json; version=3" \
-                "https://api.heroku.com/apps/$HEROKU_APP/releases" \
-                | jq -r 'sort_by(.created_at) | last | .status // empty')
-
-              if [ "$RELEASE_STATUS" = "succeeded" ]; then
-                echo "Heroku release succeeded ✅"
-                break
-              elif [ "$RELEASE_STATUS" = "failed" ]; then
-                echo "Heroku release FAILED ❌" >&2
-                heroku releases --app "$HEROKU_APP" --json | jq -r '.[0] | "Release v\(.version): \(.description) — Status: \(.status)"' || true
-                exit 1
-              fi
-
-              sleep 5
-            done
-
-            if [ "$RELEASE_STATUS" != "succeeded" ]; then
-              echo "Timed out waiting for Heroku release status." >&2
-              exit 1
-            fi

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -83,19 +83,22 @@ Walk through Cloudflare DNS + SSL setup. Only relevant if they have a custom dom
 
 ## Section 3: CircleCI
 
-Walk through CI/CD pipeline setup.
+Walk through CI/CD pipeline setup. The pipeline builds Docker images, pushes to GHCR, and deploys to Render via its API.
 
 1. **Account** — https://circleci.com/signup/ (recommend GitHub signup)
 2. **Add project** — Projects -> Set Up Project, select "Use existing config"
 3. **Docker Hub credentials** — They need a Docker Hub account (https://hub.docker.com/signup) and access token
    - Add DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD to CircleCI project environment variables
-4. **Deploy hooks** — If they want CircleCI to trigger deploys (vs Render auto-deploy):
-   - Get deploy hook URLs from Render dashboard (Web Service -> Settings -> Deploy Hook)
-   - Add RENDER_DEPLOY_HOOK_SERVER (and optionally RENDER_DEPLOY_HOOK_PRODUCTION) to CircleCI env vars
-5. **Update config** — Offer to update `.circleci/config.yml` to replace any Heroku references with Render deploy hooks
-   - Read the current config first to see what needs changing
-   - The deploy step should `curl` the deploy hook URL
-   - Keep the existing test/lint jobs
+4. **GHCR context** — Create a `ghcr` context in CircleCI Organization Settings -> Contexts:
+   - `GHCR_USERNAME` — GitHub username or org name
+   - `GHCR_TOKEN` — GitHub Personal Access Token with `write:packages` scope (create at https://github.com/settings/tokens)
+5. **Render context** — Create a `render` context in CircleCI:
+   - `RENDER_API_KEY` — From Render Account Settings -> API Keys
+   - `RENDER_STAGING_SERVICE_ID` — Service ID for staging-server (from the service URL: `srv-xxxxx`)
+   - `RENDER_STAGING_WORKER_SERVICE_ID` — Service ID for staging-worker (optional)
+   - `RENDER_PRODUCTION_SERVICE_ID` — Service ID for production-server
+   - `RENDER_PRODUCTION_WORKER_SERVICE_ID` — Service ID for production-worker (optional)
+6. **Update render.yaml** — Replace `YOUR_ORG/YOUR_REPO` in `render.yaml` with the GHCR image path (e.g. `ghcr.io/myorg/myrepo`)
 
 ## Section 4: Google OAuth
 

--- a/Makefile
+++ b/Makefile
@@ -89,16 +89,6 @@ generate-migration:
 worker-debug:
 	$(COMPOSE) exec server npm run worker:debug
 
-# --- Heroku DB Backup/Restore (uncomment and configure) ---
-# HEROKU_PROD_APP := your-prod-app
-# HEROKU_STAGING_APP := your-staging-app
-#
-# db-backup:
-# 	heroku pg:backups:capture --app $(HEROKU_PROD_APP)
-#
-# db-restore-staging:
-# 	heroku pg:backups:restore $(HEROKU_PROD_APP)::b001 DATABASE_URL --app $(HEROKU_STAGING_APP) --confirm $(HEROKU_STAGING_APP)
-
 .PHONY: find-open-ports install launch launch-detached terminate restart logs logs-server logs-client \
 	test-server test-server-file test-server-with-logging test-server-debug test-client \
 	lint-server lint-client prettier-server prettier-client \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ A production-ready full-stack TypeScript starter with authentication, protected 
 
 - Docker Compose for local development
 - Automatic port management (multiple instances supported)
-- CircleCI CI/CD pipeline
+- Render for staging and production hosting
+- CircleCI CI/CD pipeline (build, test, deploy to Render)
 - GitHub Actions release PR automation
 - Claude Code skills for AI-assisted development
 
@@ -210,21 +211,89 @@ Available at:
 
 Each endpoint module has a co-located `.api.docs.yaml` file. See `server/src/api/auth/` for the reference pattern.
 
-## Setting up CircleCI
+## Deploying to Render
+
+### Overview
+
+The project uses [Render](https://render.com) for staging and production hosting. Docker images are built by CircleCI, pushed to GitHub Container Registry (GHCR), and deployed to Render via its API.
+
+**Pipeline flow:**
+
+1. Push to `develop` → CircleCI builds & tests → Docker image pushed to GHCR as `:staging` → deployed to Render staging
+2. Push to `main` → CircleCI builds & tests → `:staging` image promoted to `:production` → deployed to Render production
+
+### Initial Render Setup
+
+1. **Create a Render account** at https://render.com
+
+2. **Update `render.yaml`** — Replace `YOUR_ORG/YOUR_REPO` with your GitHub org and repo name (e.g. `ghcr.io/myorg/myapp:staging`)
+
+3. **Create a PostgreSQL database** in Render for each environment (staging and production)
+
+4. **Create environment variable groups** in the Render dashboard:
+   - `staging` — with `DATABASE_URL`, `JWT_SECRET`, and any other env vars from `server/.env-example`
+   - `production` — same keys, production values
+
+5. **Create the services** using the Render Blueprint:
+   - Go to Render Dashboard → **Blueprints** → **New Blueprint Instance**
+   - Connect your GitHub repo and select the `render.yaml` file
+   - Render will create the staging-server, staging-worker, production-server, and production-worker services
+
+6. **Note the service IDs** — You'll need these for CircleCI. Find them in each service's Settings page URL (the `srv-xxxxx` value).
+
+### CircleCI Setup
 
 1. Sign up at https://circleci.com/ and connect your GitHub repository
+
 2. Add these environment variables in CircleCI project settings:
    - `DOCKERHUB_USERNAME` — Docker Hub username
    - `DOCKERHUB_PASSWORD` — Docker Hub access token
-3. The CI pipeline runs server build + tests, linting, and client tests
 
-## Release Workflow
+3. Create a **`ghcr`** context in CircleCI with:
+   - `GHCR_USERNAME` — Your GitHub username or org name
+   - `GHCR_TOKEN` — A GitHub Personal Access Token with `write:packages` scope
+
+4. Create a **`render`** context in CircleCI with:
+   - `RENDER_API_KEY` — Render API key (from Account Settings → API Keys)
+   - `RENDER_STAGING_SERVICE_ID` — Service ID for `staging-server`
+   - `RENDER_STAGING_WORKER_SERVICE_ID` — Service ID for `staging-worker` (optional)
+   - `RENDER_PRODUCTION_SERVICE_ID` — Service ID for `production-server`
+   - `RENDER_PRODUCTION_WORKER_SERVICE_ID` — Service ID for `production-worker` (optional)
+
+### Deploying to Staging
+
+Merge a PR into `develop`. CircleCI will automatically:
+1. Build and test the server
+2. Build the production Docker image
+3. Push it to GHCR tagged as `:staging`
+4. Trigger a deploy on Render staging
+5. Wait for the deploy to go live
+
+### Deploying to Production
+
+Merge `develop` into `main`. CircleCI will automatically:
+1. Build and test the server
+2. Pull the `:staging` image, re-tag it as `:production`, and push to GHCR
+3. Trigger a deploy on Render production
+4. Wait for the deploy to go live
+
+### Release Workflow
 
 To create a release PR from `develop` to `main`:
 
 1. Go to GitHub Actions -> "Create Release PR" -> Run workflow
 2. Choose version bump type (patch/minor/major) and enter a release title
 3. A PR is auto-created with the version bump and commit summary
+
+### Production Docker Image
+
+To build the production image locally for testing:
+
+```bash
+cd server
+docker build -f Dockerfile.production -t myapp:local .
+docker run -p 10020:10020 --env-file .env myapp:local
+```
 
 ## Contributing
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,60 @@
+services:
+  - type: web
+    name: staging-server
+    runtime: image
+    image:
+      url: ghcr.io/YOUR_ORG/YOUR_REPO:staging
+    region: ohio
+    plan: starter
+    startCommand: node dist/server.js
+    preDeployCommand: node dist/scripts/checkEnv.js && npx sequelize-cli --options-path=.sequelizerc db:migrate
+    autoDeploy: false
+    healthCheckPath: /v1/healthCheck
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - fromGroup: staging
+
+  - type: worker
+    name: staging-worker
+    runtime: image
+    image:
+      url: ghcr.io/YOUR_ORG/YOUR_REPO:staging
+    region: ohio
+    plan: starter
+    startCommand: node dist/worker.js
+    autoDeploy: false
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - fromGroup: staging
+
+  - type: web
+    name: production-server
+    runtime: image
+    image:
+      url: ghcr.io/YOUR_ORG/YOUR_REPO:production
+    region: ohio
+    plan: starter
+    startCommand: node dist/server.js
+    preDeployCommand: node dist/scripts/checkEnv.js && npx sequelize-cli --options-path=.sequelizerc db:migrate
+    autoDeploy: false
+    healthCheckPath: /v1/healthCheck
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - fromGroup: production
+
+  - type: worker
+    name: production-worker
+    runtime: image
+    image:
+      url: ghcr.io/YOUR_ORG/YOUR_REPO:production
+    region: ohio
+    plan: starter
+    startCommand: node dist/worker.js
+    autoDeploy: false
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - fromGroup: production

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env-test
+*.test.ts

--- a/server/Dockerfile.production
+++ b/server/Dockerfile.production
@@ -1,0 +1,28 @@
+FROM node:22.15.0-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY src/ ./src/
+COPY tsconfig.json .sequelizerc ./
+RUN npm run build-ts
+
+# ---
+FROM node:22.15.0-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist/ ./dist/
+COPY --from=build /app/.sequelizerc ./
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+EXPOSE 10020
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["web"]

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+case "${1:-web}" in
+  web)     exec node dist/server.js ;;
+  worker)  exec node dist/worker.js ;;
+  release) node dist/scripts/checkEnv.js && exec npx sequelize-cli --options-path=.sequelizerc db:migrate ;;
+  *)       exec "$@" ;;
+esac


### PR DESCRIPTION
## Summary

- Add `render.yaml` blueprint with staging and production services (web + worker for each environment), using GHCR images, pre-deploy migrations, and health checks
- Add `server/Dockerfile.production` (multi-stage build) and `server/docker-entrypoint.sh` for containerized deployments
- Replace all Heroku CI/CD workflows in `.circleci/config.yml` with GHCR image build/push and Render API deploy with status polling
- Update README with full Render deployment instructions (initial setup, CircleCI contexts, staging/production flows)
- Remove all Heroku references from Makefile and deploy skill

## Test plan

- [ ] Verify CircleCI config syntax is valid
- [ ] Build production Docker image locally: `cd server && docker build -f Dockerfile.production -t test:local .`
- [ ] Confirm `render.yaml` is accepted by Render Blueprint
- [ ] End-to-end: push to `develop`, verify staging deploy completes