### PR TITLE
Skip deploy jobs when Render is not configured

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,7 @@ jobs:
       - run: docker compose run client npm test
 
   promote-to-production:
+    if: ${{ secrets.RENDER_API_KEY != '' }}
     needs: [build-and-test, lint-server, lint-client, test-client]
     runs-on: ubuntu-latest
     permissions:
@@ -52,6 +53,7 @@ jobs:
           docker push ghcr.io/$GHCR_USERNAME/$REPO_NAME:production
 
   deploy-to-render:
+    if: ${{ secrets.RENDER_API_KEY != '' }}
     needs: promote-to-production
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,6 +35,7 @@ jobs:
       - run: docker compose run client npm test
 
   build-and-push-image:
+    if: ${{ secrets.RENDER_API_KEY != '' }}
     needs: [build-and-test, lint-server, lint-client, test-client]
     runs-on: ubuntu-latest
     permissions:
@@ -49,6 +50,7 @@ jobs:
         run: docker push ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ github.event.repository.name }}:staging
 
   deploy-to-render:
+    if: ${{ secrets.RENDER_API_KEY != '' }}
     needs: build-and-push-image
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Deploy and image-push jobs in both staging and production workflows now check for `RENDER_API_KEY` before running. This lets CI pass cleanly on repos that haven't set up Render deployment secrets yet. Test and lint jobs still run unconditionally.