### PR TITLE
Add release version to healthcheck response

### DIFF
--- a/server/src/api/healthCheck/healthCheck.api.test.ts
+++ b/server/src/api/healthCheck/healthCheck.api.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import request from 'supertest';
 
 import app from '../../server';
+import { version } from '../../../package.json';
 
 describe('Authorization and Authentication', function () {
   describe('HealthCheck', function () {
@@ -12,6 +13,7 @@ describe('Authorization and Authentication', function () {
         .end(function (err, res) {
           if (err) return done(err);
           assert.equal(res.body.healthy, true);
+          assert.equal(res.body.version, version);
           done();
         });
     });

--- a/server/src/api/healthCheck/healthCheck.api.ts
+++ b/server/src/api/healthCheck/healthCheck.api.ts
@@ -1,7 +1,8 @@
 import { RequestHandler } from 'express';
+import { version } from '../../../package.json';
 
 const healthCheckEndpoint: RequestHandler = (_req, res) => {
-  res.status(200).json({ healthy: true });
+  res.status(200).json({ healthy: true, version });
 };
 
 export default {


### PR DESCRIPTION
Imports the version from package.json and includes it in the healthcheck endpoint response (`{ healthy: true, version }`), matching the pattern used in the playola project. Test updated to assert the version is present.