### PR TITLE
feat: add create-release-pr make target and skill

### DIFF
--- a/.claude/skills/create-release-pr/SKILL.md
+++ b/.claude/skills/create-release-pr/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: create-release-pr
+description: Analyze PRs merged to develop since last release, determine version bump, and create a release PR from develop into main
+---
+
+# Create Release PR
+
+Create a release PR from `develop` into `main` by analyzing merged PRs, determining the version bump type, and triggering the release workflow.
+
+## Step 1: Fetch and identify PRs in this release
+
+Run these commands to gather the release contents:
+
+```bash
+git fetch origin main develop --quiet
+```
+
+Find the last release merge commit (develop merged into main):
+
+```bash
+LAST_RELEASE=$(git log origin/main --merges --pretty=format:"%H %s" 2>/dev/null \
+  | grep "from .*/develop$" \
+  | head -1 \
+  | awk '{print $1}')
+
+if [ -z "$LAST_RELEASE" ]; then
+  BASE="origin/main"
+else
+  BASE="$LAST_RELEASE"
+fi
+```
+
+Extract PR numbers from both merge commits and squash-merged commits:
+
+```bash
+# Merge commits: "Merge pull request #123 ..."
+git log "$BASE"..origin/develop --merges --pretty=format:"%s" 2>/dev/null | grep "^Merge pull request" | grep -oE '#[0-9]+'
+
+# Squash-merged commits: "feat: some feature (#123)"
+git log "$BASE"..origin/develop --no-merges --pretty=format:"%s" 2>/dev/null | grep -oE '\(#[0-9]+\)' | grep -oE '#[0-9]+'
+```
+
+For each PR number, fetch the title and labels using `gh pr view <num> --json title,labels,body`.
+
+## Step 2: Determine the version bump type
+
+Read the current version from `server/package.json`.
+
+Analyze the PRs to determine the bump type:
+
+- **major** — Any PR introduces a breaking change (look for "BREAKING" in title/body, or a `breaking` label)
+- **minor** — Any PR adds new features (title starts with `feat:`, or has `feature`/`enhancement` label)
+- **patch** — All PRs are bug fixes, chores, refactors, docs, or other non-feature work
+
+Default to **patch** if uncertain. Present your reasoning to the user and ask them to confirm the bump type before proceeding.
+
+Calculate the new version:
+- patch: increment the third number (e.g., 1.2.3 → 1.2.4)
+- minor: increment the second number, reset third (e.g., 1.2.3 → 1.3.0)
+- major: increment the first number, reset second and third (e.g., 1.2.3 → 2.0.0)
+
+## Step 3: Generate the release title
+
+Create a short, descriptive title (under 60 characters) that summarizes the theme of the release based on the PR titles. Examples:
+- "Station Analytics & Voicetrack Improvements"
+- "Invite Code System & Bug Fixes"
+- "SQL Injection Protection"
+
+Present the proposed title to the user and ask them to confirm or suggest an alternative.
+
+## Step 4: Trigger the release workflow
+
+Once the user confirms the bump type and title, trigger the GitHub Actions workflow:
+
+```bash
+gh workflow run create-release-pr.yml -f version_bump="<bump_type>" -f release_title="<title>"
+```
+
+## Step 5: Monitor and report
+
+Wait 10 seconds for GitHub to register the new workflow run, then check its status:
+
+```bash
+gh run list --workflow=create-release-pr.yml --limit=1 --json status,conclusion,url
+```
+
+Once the workflow completes, find and display the created PR:
+
+```bash
+gh pr list --base main --head develop --json number,title,url
+```
+
+Report the PR URL to the user.
+
+## Output Format
+
+Present the release summary as:
+
+```
+## Release Summary
+
+**Version:** {old_version} → {new_version} ({bump_type})
+**Title:** {new_version} - {release_title}
+
+### PRs included:
+- #{number}: {title}
+- #{number}: {title}
+...
+
+**Workflow triggered.** PR will be created at: {url}
+```

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,11 @@ generate-migration:
 worker-debug:
 	$(COMPOSE) exec server npm run worker:debug
 
+create-release-pr:
+	./scripts/release.sh
+
 .PHONY: find-open-ports install launch launch-detached terminate restart logs logs-server logs-client \
 	test-server test-server-file test-server-with-logging test-server-debug test-client \
 	lint-server lint-client prettier-server prettier-client \
 	prettier-all build-server build-client build-and-test-server migrate migrate-all \
-	generate-migration worker-debug
+	generate-migration worker-debug create-release-pr

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -e
+
+echo "Create Release PR"
+echo "=================="
+echo ""
+
+# Fetch latest refs
+git fetch origin main develop --quiet
+
+# Find the last release merge (develop merged into main) to use as the base.
+# This handles squash merges correctly — origin/main..origin/develop misses
+# squash-merged PRs because those commits are reachable from both branches
+# after a release merge.
+LAST_RELEASE=$(git log origin/main --merges --pretty=format:"%H %s" 2>/dev/null \
+  | grep "from .*/develop$" \
+  | head -1 \
+  | awk '{print $1}')
+
+if [ -z "$LAST_RELEASE" ]; then
+  BASE="origin/main"
+else
+  BASE="$LAST_RELEASE"
+fi
+
+echo "PRs in this release:"
+echo "--------------------"
+{
+  # Merge commits: "Merge pull request #123 ..."
+  git log "$BASE"..origin/develop --merges --pretty=format:"%s" 2>/dev/null | grep "^Merge pull request" | grep -oE '#[0-9]+'
+  # Squash-merged commits: "feat: some feature (#123)"
+  git log "$BASE"..origin/develop --no-merges --pretty=format:"%s" 2>/dev/null | grep -oE '\(#[0-9]+\)' | grep -oE '#[0-9]+'
+} | sort -t'#' -k1 -rn | uniq | while read pr; do
+  num=${pr#\#}
+  title=$(gh pr view "$num" --json title --jq '.title' 2>/dev/null)
+  echo "  $pr: $title"
+done
+echo ""
+
+read -p "Release title: " release_title
+
+if [ -z "$release_title" ]; then
+  echo "Release title is required. Exiting."
+  exit 1
+fi
+
+echo ""
+echo "Select version bump type:"
+echo "  1) patch  - Bug fixes, small changes (0.0.X)"
+echo "  2) minor  - New features, backwards compatible (0.X.0)"
+echo "  3) major  - Breaking changes (X.0.0)"
+echo ""
+
+read -p "Enter choice [1-3]: " choice
+
+case $choice in
+  1)
+    bump_type="patch"
+    ;;
+  2)
+    bump_type="minor"
+    ;;
+  3)
+    bump_type="major"
+    ;;
+  *)
+    echo "Invalid choice. Exiting."
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "Creating $bump_type release PR: \"$release_title\"..."
+echo ""
+
+gh workflow run create-release-pr.yml -f version_bump="$bump_type" -f release_title="$release_title"
+
+echo "Workflow triggered! View progress at:"
+gh run list --workflow=create-release-pr.yml --limit=1


### PR DESCRIPTION
## Summary

- Add `scripts/release.sh` — interactive script that fetches latest refs, lists PRs merged to develop since last release, prompts for a title and version bump type, then triggers the `create-release-pr.yml` GitHub Actions workflow
- Add `create-release-pr` make target to invoke the release script
- Add `/create-release-pr` Claude Code skill definition for AI-assisted release PR creation

## Test plan
- [x] Shell script is executable and matches the proven playola implementation
- [x] Make target wires to the script correctly
- [x] Skill definition follows the existing skill pattern in `.claude/skills/`
- [x] No application code changes — tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)