### PR TITLE
Fix deploy workflows failing with 'no jobs were run'

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,9 +34,25 @@ jobs:
       - run: touch ./server/.env
       - run: docker compose run client npm test
 
+  check-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          if [ -n "$RENDER_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::RENDER_API_KEY not configured, skipping deploy"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+
   promote-to-production:
-    if: ${{ secrets.RENDER_API_KEY != '' }}
-    needs: [build-and-test, lint-server, lint-client, test-client]
+    if: needs.check-deploy.outputs.enabled == 'true'
+    needs: [build-and-test, lint-server, lint-client, test-client, check-deploy]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -53,8 +69,8 @@ jobs:
           docker push ghcr.io/$GHCR_USERNAME/$REPO_NAME:production
 
   deploy-to-render:
-    if: ${{ secrets.RENDER_API_KEY != '' }}
-    needs: promote-to-production
+    if: needs.check-deploy.outputs.enabled == 'true'
+    needs: [promote-to-production, check-deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy production services on Render

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -34,9 +34,25 @@ jobs:
       - run: touch ./server/.env
       - run: docker compose run client npm test
 
+  check-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        run: |
+          if [ -n "$RENDER_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::RENDER_API_KEY not configured, skipping deploy"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+
   build-and-push-image:
-    if: ${{ secrets.RENDER_API_KEY != '' }}
-    needs: [build-and-test, lint-server, lint-client, test-client]
+    if: needs.check-deploy.outputs.enabled == 'true'
+    needs: [build-and-test, lint-server, lint-client, test-client, check-deploy]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -50,8 +66,8 @@ jobs:
         run: docker push ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ github.event.repository.name }}:staging
 
   deploy-to-render:
-    if: ${{ secrets.RENDER_API_KEY != '' }}
-    needs: build-and-push-image
+    if: needs.check-deploy.outputs.enabled == 'true'
+    needs: [build-and-push-image, check-deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy staging services on Render


### PR DESCRIPTION
## Summary
- The `if: ${{ secrets.RENDER_API_KEY != '' }}` on job-level `if` conditions causes GitHub Actions to fail the entire workflow with "no jobs were run" — secrets aren't reliably evaluable at that scope
- Added a lightweight `check-deploy` job that tests for the secret at the step level (where it works) and exposes the result as a job output
- Downstream deploy jobs now gate on `needs.check-deploy.outputs.enabled` instead of referencing secrets directly
- Fixed in both `deploy-staging.yml` and `deploy-production.yml`

## Test plan
- [ ] Merge to develop and verify the staging workflow runs test/lint jobs successfully
- [ ] Verify deploy jobs are properly skipped (not errored) when RENDER_API_KEY isn't configured